### PR TITLE
fix the REQUIRE_ESM error in vc-export package

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,3 +13,5 @@ plugins:
     spec: '@yarnpkg/plugin-workspace-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs
+
+npmAuthToken: ${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "typedoc": "^0.22.15",
     "typescript": "^4.8.3"
   },
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "packageManager": "yarn@3.2.1"
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/config",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/messaging",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/modules",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "Core Modules",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/network",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/sdk",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/types",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/utils",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/vc-export",
-  "version": "0.7.8-1",
+  "version": "0.7.8-6",
   "description": "Verifiable Credentials",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/vc-export/src/suites/documentLoader.ts
+++ b/packages/vc-export/src/suites/documentLoader.ts
@@ -1,10 +1,10 @@
 import type { RemoteDocument, Url } from 'jsonld/jsonld-spec'
-import * as vcjs from '@digitalbazaar/vc'
 import { validationContexts } from './context/index.js'
 
 export async function documentLoader(url: Url): Promise<RemoteDocument> {
   const context = validationContexts[url]
   if (context)
     return { contextUrl: undefined, documentUrl: url, document: context }
+  const vcjs = await import('@digitalbazaar/vc');
   return vcjs.defaultDocumentLoader(url)
 }

--- a/packages/vc-export/tsconfig.esm.json
+++ b/packages/vc-export/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "module": "ES6",
+    "module": "esnext",
     "outDir": "./lib/esm"
   }
 }


### PR DESCRIPTION
```
app     | /app/node_modules/@cord.network/vc-export/lib/cjs/suites/documentLoader.js:5
app     | const vcjs = (0, tslib_1.__importStar)(require("@digitalbazaar/vc"));
app     |                                        ^
app     |
app     | Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/@digitalbazaar/vc/lib/index.js from /app/node_modules/@cord.network/vc-export/lib/cjs/suites/documentLoader.js not supported.
app     | Instead change the require of index.js in /app/node_modules/@cord.network/vc-export/lib/cjs/suites/documentLoader.js to a dynamic import() which is available in all CommonJS modules.
```

above issue used to come when we were using vc-export in any application. Fixed with this commit

Signed-off-by: Amar Tumballi <amar@dhiway.com>