### PR TITLE
Option to specify Blake2b bitLength

### DIFF
--- a/packages/modules/src/score/Score.chain.ts
+++ b/packages/modules/src/score/Score.chain.ts
@@ -10,7 +10,6 @@ import type {
   IJournalContent,
   IScoreAggregateDetails,
   IScoreAverageDetails,
-  // IPublicIdentity,
   SubmittableExtrinsic,
 } from '@cord.network/types'
 import { DecoderUtils } from '@cord.network/utils'

--- a/packages/modules/src/score/Score.ts
+++ b/packages/modules/src/score/Score.ts
@@ -54,7 +54,7 @@ export function fromJournalProperties(
 ): IJournal {
   let journalScore = Number(journalProperties.score.toFixed(1)) * 10
   journalProperties.score = journalScore
-  const journalHash = Crypto.hashObjectAsHexStr(journalProperties)
+  const journalHash = Crypto.hashObjectAsHexStr(journalProperties, 512)
 
   const journalId = Identifier.getIdentifier(
     journalHash,

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -214,8 +214,8 @@ export function hash(value: CryptoInput, bitLength?: BitLength): Uint8Array {
  * @param value Value to be hashed.
  * @returns Blake2b hash as hex string.
  */
-export function hashStr(value: CryptoInput): HexString {
-  return u8aToHex(hash(value))
+export function hashStr(value: CryptoInput, bitLength?: BitLength ): HexString {
+  return u8aToHex(hash(value, bitLength))
 }
 
 /**
@@ -250,13 +250,14 @@ export function encodeObjectAsStr(
  */
 export function hashObjectAsHexStr(
   value: Record<string, any> | string | number | boolean,
-  nonce?: string
+  bitLength?: BitLength,
+  nonce?: string,
 ): HexString {
   let objectAsStr = encodeObjectAsStr(value)
   if (nonce) {
     objectAsStr = nonce + objectAsStr
   }
-  return hashStr(objectAsStr)
+  return hashStr(objectAsStr, bitLength)
 }
 
 /**


### PR DESCRIPTION
Create the blake2b hash and return the result as a u8a with the specified `bitLength`.

Supported bitLength -  64 | 128 | 256 | 384 | 512