### PR TITLE
add 'vc-export' module to export Verifiable Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ Note that **before you see your changes from the SDK, you have to build it**, by
 ```
 yarn build
 ```
+
+## Experiment the SDK methods
+
+
+Once the build of the package is complete (with `yarn build`), one can try below methods to check
+if methods are working.
+
+```
+
+$ yarn demo
+
+$ yarn demo-vc
+
+$ yarn bench
+
+```
+The output of these runs are self-explanatory. For reference of how this is structured,
+you can refer to the source of the demo scripts.
+

--- a/demo/src/demo-vc.ts
+++ b/demo/src/demo-vc.ts
@@ -22,7 +22,7 @@ import { encryptMessage } from './utils/encrypt_message'
 import { generateRequestCredentialMessage } from './utils/request_credential_message'
 import { getChainCredits, addAuthority } from './utils/createAuthorities'
 import { createAccount } from './utils/createAccount'
-import { VerifiableCredential } from '@cord.network/vc-export/lib/cjs/types'
+import { VerifiableCredential } from '@cord.network/vc-export'
 
 function getChallenge(): string {
   return Cord.Utils.UUID.generate()
@@ -242,30 +242,17 @@ async function main() {
   console.dir(vcPresentation, { depth: null, colors: true })
   console.log('✅ Verifiable Presentation created!')
 
-  /*
   console.log(`\n❄️  Verifiy Presentation`)
 
   const VCfromPresentation =
     vcPresentation.verifiableCredential as VerifiableCredential
 
-  const streamSignatureResult =
-    await VCUtils.verification.verifyStreamSignatureProof(
-      VCfromPresentation,
-      VCfromPresentation.proof[0]
-    )
-
-    console.log("\n: VC Proof(0): ", VCfromPresentation.proof[0], streamSignatureResult)
-    const streamResult = await VCUtils.verification.verifyStreamProof(
+  const streamResult = await VCUtils.verification.verifyStreamProof(
     VCfromPresentation,
     VCfromPresentation.proof[1]
   )
   console.log("\n: VC Proof(1): ", VCfromPresentation.proof[1], streamResult)
 
-  const digestResult = await VCUtils.verification.verifyCredentialDigestProof(
-    VCfromPresentation,
-    VCfromPresentation.proof[2]
-  )
-  console.log("\n: VC Proof(2): ", VCfromPresentation.proof[2], digestResult)
   const selfSignatureResult =
     await VCUtils.verification.verifySelfSignatureProof(
       VCfromPresentation,
@@ -273,6 +260,20 @@ async function main() {
       vcChallenge
     )
     console.log("\n: VP Proof: ", vcPresentation.proof, vcChallenge, selfSignatureResult)
+
+    const digestResult = await VCUtils.verification.verifyCredentialDigestProof(
+      VCfromPresentation,
+      VCfromPresentation.proof[2]
+    )
+    console.log("\n: VC Proof(2): ", VCfromPresentation.proof[2], digestResult)
+    
+  const streamSignatureResult =
+    await VCUtils.verification.verifyStreamSignatureProof(
+      VCfromPresentation,
+      VCfromPresentation.proof[0]
+    )
+
+  console.log("\n: VC Proof(0): ", VCfromPresentation.proof[0], streamSignatureResult)
   
   if (
     streamResult &&
@@ -308,7 +309,6 @@ async function main() {
       selfSignatureResult['verified']
     )
   }
-  */
 }
 
 main()

--- a/demo/src/demo-vc.ts
+++ b/demo/src/demo-vc.ts
@@ -251,7 +251,7 @@ async function main() {
     VCfromPresentation,
     VCfromPresentation.proof[1]
   )
-  console.log("\n: VC Proof(1): ", VCfromPresentation.proof[1], streamResult)
+  //console.log("\n: VC Proof(1): ", VCfromPresentation.proof[1], streamResult)
 
   const selfSignatureResult =
     await VCUtils.verification.verifySelfSignatureProof(
@@ -259,13 +259,13 @@ async function main() {
       vcPresentation.proof[0],
       vcChallenge
     )
-    console.log("\n: VP Proof: ", vcPresentation.proof, vcChallenge, selfSignatureResult)
+    //console.log("\n: VP Proof: ", vcPresentation.proof, vcChallenge, selfSignatureResult)
 
     const digestResult = await VCUtils.verification.verifyCredentialDigestProof(
       VCfromPresentation,
       VCfromPresentation.proof[2]
     )
-    console.log("\n: VC Proof(2): ", VCfromPresentation.proof[2], digestResult)
+    //console.log("\n: VC Proof(2): ", VCfromPresentation.proof[2], digestResult)
     
   const streamSignatureResult =
     await VCUtils.verification.verifyStreamSignatureProof(
@@ -273,7 +273,7 @@ async function main() {
       VCfromPresentation.proof[0]
     )
 
-  console.log("\n: VC Proof(0): ", VCfromPresentation.proof[0], streamSignatureResult)
+  //console.log("\n: VC Proof(0): ", VCfromPresentation.proof[0], streamSignatureResult)
   
   if (
     streamResult &&
@@ -309,6 +309,84 @@ async function main() {
       selfSignatureResult['verified']
     )
   }
+
+  console.log(`\n❄️  Revoke credential - ${document.identifier}`)
+  await revokeCredential(
+    delegateTwoDid.uri,
+    authorIdentity,
+    async ({ data }) => ({
+      signature: delegateTwoKeys.assertionMethod.sign(data),
+      keyType: delegateTwoKeys.assertionMethod.type,
+    }),
+    document,
+    false
+  )
+  console.log(`✅ Credential revoked!`)
+
+  /* Test VC & VP after revoke */
+  const streamResult1 = await VCUtils.verification.verifyStreamProof(
+    VCfromPresentation,
+    VCfromPresentation.proof[1]
+  )
+  //console.log("\n: VC Proof(1): ", VCfromPresentation.proof[1], streamResult)
+
+  const selfSignatureResult1 =
+    await VCUtils.verification.verifySelfSignatureProof(
+      VCfromPresentation,
+      vcPresentation.proof[0],
+      vcChallenge
+    )
+    //console.log("\n: VP Proof: ", vcPresentation.proof, vcChallenge, selfSignatureResult)
+
+    const digestResult1 = await VCUtils.verification.verifyCredentialDigestProof(
+      VCfromPresentation,
+      VCfromPresentation.proof[2]
+    )
+    //console.log("\n: VC Proof(2): ", VCfromPresentation.proof[2], digestResult)
+    
+  const streamSignatureResult1 =
+    await VCUtils.verification.verifyStreamSignatureProof(
+      VCfromPresentation,
+      VCfromPresentation.proof[0]
+    )
+
+  //console.log("\n: VC Proof(0): ", VCfromPresentation.proof[0], streamSignatureResult)
+  
+  if (
+    streamResult1 &&
+    streamResult1['verified'] &&
+    digestResult1 &&
+    digestResult1['verified'] &&
+    streamSignatureResult1 &&
+    streamSignatureResult1['verified'] &&
+    selfSignatureResult1 &&
+    selfSignatureResult1['verified']
+  ) {
+    console.log(
+      '✅',
+      'Stream-Signature-Proof',
+      streamSignatureResult1['verified'],
+      '✧ Stream-Proof',
+      streamResult1['verified'],
+      '✧ Digest-Proof',
+      digestResult1['verified'],
+      '✧ Self-Signature-Proof',
+      selfSignatureResult1['verified']
+    )
+  } else {
+    console.log(
+      `❌`,
+      'Stream-Signature-Proof',
+      streamSignatureResult1['verified'],
+      '✧ Stream-Proof',
+      streamResult1,
+      '✧ Digest-Proof',
+      digestResult1['verified'],
+      '✧ Self-Signature-Proof',
+      selfSignatureResult1['verified']
+    )
+  }
+
 }
 
 main()

--- a/packages/modules/src/content/Content.ts
+++ b/packages/modules/src/content/Content.ts
@@ -34,8 +34,8 @@ function jsonLDcontents(
   if (!schemaId) new SDKErrors.SchemaIdentifierMissingError()
   const vocabulary = `${schemaId}#`
   const result: Record<string, unknown> = {}
-  if (issuer) result['@issuer'] = issuer
-  if (holder) result['@holder'] = holder
+  if (issuer) result['issuer'] = issuer
+  if (holder) result['holder'] = holder
 
   if (!expanded) {
     return {

--- a/packages/modules/src/document/Document.ts
+++ b/packages/modules/src/document/Document.ts
@@ -71,15 +71,12 @@ function getHashLeaves(
  */
 
 export function calculateDocumentHash(document: Partial<IDocument>): Hash {
-  /*
   const hashes = getHashLeaves(
     document.contentHashes || [],
     document.evidenceIds || [],
     document.createdAt || '',
     document.validUntil || ''
   )
-  */
-  const hashes = getHashLeaves(document.contentHashes || [], [], '', '');
   const root = getHashRoot(hashes)
   return Crypto.u8aToHex(root)
 }

--- a/packages/modules/src/document/Document.ts
+++ b/packages/modules/src/document/Document.ts
@@ -53,10 +53,10 @@ function getHashLeaves(
       result.push(Crypto.coToUInt8(evidence.identifier))
     })
   }
-  if (createdAt) {
+  if (createdAt && createdAt !== '') {
     result.push(Crypto.coToUInt8(createdAt))
   }
-  if (validUntil) {
+  if (validUntil && validUntil !== '') {
     result.push(Crypto.coToUInt8(validUntil))
   }
 
@@ -71,12 +71,15 @@ function getHashLeaves(
  */
 
 export function calculateDocumentHash(document: Partial<IDocument>): Hash {
+  /*
   const hashes = getHashLeaves(
     document.contentHashes || [],
     document.evidenceIds || [],
     document.createdAt || '',
     document.validUntil || ''
   )
+  */
+  const hashes = getHashLeaves(document.contentHashes || [], [], '', '');
   const root = getHashRoot(hashes)
   return Crypto.u8aToHex(root)
 }

--- a/packages/vc-export/LICENSE
+++ b/packages/vc-export/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/vc-export/README.md
+++ b/packages/vc-export/README.md
@@ -1,0 +1,108 @@
+Data sovereignty and interoperability
+
+# Verifiable Credentials Compatibility Package
+
+This package helps you to translate CORD credentials to the popular [Verifiable Credential](https://www.w3.org/TR/vc-data-model/) format and structure.
+It provides you with tools to export your existing CORD credentials to the widely understood Verifiable Credential, produce Verifiable Presentations from a Verifiable Credential, and to verify the associated proofs.
+
+## Contents
+
+- exporting
+  - `fromMarkedStream()`: translates `MarkedStream` to `VerifiableCredential`
+- presentation utils
+  - `makePresentation()`: creates `VerifiablePresentation` ()
+  - `removeProperties()`: derives a new `VerifiableCredential` from an existing one with a reduced set of disclosed attributes
+- verification utils
+  - functions that verify three proof types:
+    - holder's self-signed proof over the credential digest
+    - credential digest proof that assures the integrity of disclosed attributes, holder identity, evidenceIds and delegations
+    - credential proof that assures the credential is attested by the identity disclosed as the `issuer` and not revoked
+  - a function to validate the disclosed stream properties against the schema of a CORD MType, which is a prescriptive schema detailing fields and their data types.
+- vc-js suites: tooling to integrate CORD VCs with `vc-js` and `jsonld-signatures^5.0.0`
+  - `suites`: contains suites to verify the three CORD proof types that secure a CORD VC.
+    - `CordIntegritySuite`: provides integrity protection for essential components of the credential while allowing for blinding of streams relating to the `credentialSubject`.
+    - `CordSignatureSuite`: verifies the signature over the root hash of a CORD credential.
+    - `CordAttestedSuite`: provides lookup functionality to the CORD blockchain to check whether a credential is attested and still valid.
+  - `context`: contains a json-ld `@context` definitions for CORD VCs.
+  - `documentLoader`: an implementation of the DocumentLoader required to use `vc-js` / `jsonld-signatures` which allows to serve essential `@context` definitions to the json-ld processor, including the `context` included here.
+
+## Examples
+
+### Presenting a CORD `MarkedStream` as a `VerifiableCredential`
+
+Given we are in possession of an attested CORD stream and the associated CORD identity:
+
+```typescript
+import Cord from '@cordnetwork/sdk'
+import type { MarkedStream, Identity } from '@cordnetwork/sdk'
+import VCUtils from '@cordnetwork/vc-export'
+
+let credential: MarkedStream
+let identity: Identity
+
+// turn the CORD credential into a VerifiableCredential
+const VC = VCUtils.fromMarkedStream(credential)
+
+// produce a reduced copy of the VC where only selected attributes are disclosed
+const nameOnly = VCUtils.presentation.removeProperties(VC, ['name'])
+// or directly produce a VerifiablePresentation, which implicitly performs the step above
+const presentation = VCUtils.presentation.makePresentation(VC, ['name'])
+```
+
+A verifier can now check the proofs attached to the VerifiableCredential but can only see the disclosed attributes:
+
+```typescript
+// Here's an example for verifying the credential proof
+let result
+presentation.verifiableCredential.proof.foreach((proof) => {
+  if (proof.type === VCUtils.types.CORD_ANCHORED_PROOF_TYPE)
+    VCUtils.verification.verifyStreamProof(proof)
+})
+
+if (result && result.verified) {
+  console.log(
+    `Name of the crook: ${presentation.verifiableCredential.credentialSubject.name}`
+  ) // prints 'Billy The Kid'
+  console.log(
+    `Reward: ${presentation.verifiableCredential.credentialSubject.reward}`
+  ) // undefined
+}
+```
+
+### Verifying a CORD VC with `vc-js`
+
+Assuming we have a CORD credential expressed as a VC (`credential`), for example as produced by the example above.
+
+```typescript
+import cord from '@cordnetwork/sdk'
+import { vcjsSuites } from '@cordnetwork/vc-export'
+import vcjs from 'vc-js'
+import jsigs from 'jsonld-signatures'
+
+// 1. set up suites
+const { CordIntegritySuite, CordSignatureSuite, CordAttestedSuite } =
+  vcjsSuites.suites
+const signatureSuite = new CordSignatureSuite()
+const integritySuite = new CordIntegritySuite()
+// the CordAttestedSuite requires a connection object that allows access to the CORD blockchain, which we can obtain via the CORD sdk
+await cord.init({ address: 'wss://full-nodes.cord.network:443' })
+const CordConnection = await cord.connect()
+const attestedSuite = new CordAttestedSuite({ CordConnection })
+
+// 2. obtain default cord context loader
+const { documentLoader } = vcjsSuites
+
+// 3. obtain the `assertionMethod` proof purpose from `jsonld-signatures`
+const purpose = new jsigs.purposes.AssertionProofPurpose()
+
+// 4. call vc-js.verifyCredential with suites and context loader
+const result = await vcjs.verifyCredential({
+  credential,
+  suite: [signatureSuite, integritySuite, attestedSuite],
+  purpose,
+  documentLoader,
+})
+
+// 5. make sure all `results` indicate successful verification
+const verified = result.results.every((i) => i.verified === true)
+```

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@cord.network/vc-export",
+  "version": "0.8.0-beta.8",
+  "description": "Verifiable Credentials",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
+  },
+  "files": [
+    "lib/**/*"
+  ],
+  "scripts": {
+    "clean": "rimraf ./lib",
+    "build": "yarn clean && yarn build:ts",
+    "build:ts": "yarn build:cjs && yarn build:esm",
+    "build:cjs": "tsc --declaration -p tsconfig.build.json && echo '{\"type\":\"commonjs\"}' > ./lib/cjs/package.json",
+    "build:esm": "tsc --declaration -p tsconfig.esm.json && echo '{\"type\":\"module\"}' > ./lib/esm/package.json"
+  },
+  "repository": "github:dhiway/cord.js",
+  "engines": {
+    "node": ">=14.0"
+  },
+  "author": "",
+  "bugs": "https://github.com/dhiway/cord.js/issues",
+  "homepage": "https://github.com/dhiway/cord.js#readme",
+  "devDependencies": {
+    "@types/jsonld": "1.5.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.8.3"
+  },
+  "dependencies": {
+    "@cord.network/modules": "workspace:*",
+    "@cord.network/network": "workspace:*",
+    "@cord.network/types": "workspace:*",
+    "@cord.network/utils": "workspace:*",
+    "@digitalbazaar/vc": "^6.0.1",
+    "bip39": "^3.1.0",
+    "jsonld": "^8.1.1",
+    "jsonld-signatures": "^5.0.0"
+  }
+}

--- a/packages/vc-export/package.json
+++ b/packages/vc-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cord.network/vc-export",
-  "version": "0.8.0-beta.8",
+  "version": "0.8.0-3",
   "description": "Verifiable Credentials",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/vc-export/src/constants.ts
+++ b/packages/vc-export/src/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * Constant for default context.
+ */
+export const DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT =
+  'https://www.w3.org/2018/credentials/v1'
+
+export const CORD_CREDENTIAL_CONTEXT_URL =
+  'https://cord.network/contexts/credentials'
+
+/**
+ * Constant for default type.
+ */
+export const DEFAULT_VERIFIABLE_CREDENTIAL_TYPE = 'VerifiableCredential'
+/**
+ * Constant for default presentation type.
+ */
+export const DEFAULT_VERIFIABLEPRESENTATION_TYPE = 'VerifiablePresentation'
+
+export const CORD_VERIFIABLE_CREDENTIAL_TYPE = 'CordCredential2020'
+
+export const CORD_STREAM_SIGNATURE_PROOF_TYPE = 'CordStreamSignature2020'
+export const CORD_SELF_SIGNATURE_PROOF_TYPE = 'CordSelfSignature2020'
+export const CORD_ANCHORED_PROOF_TYPE = 'CordCredential2020'
+export const CORD_CREDENTIAL_DIGEST_PROOF_TYPE = 'CordCredentialDigest2020'
+
+export const JSON_SCHEMA_TYPE = 'JsonSchemaValidator2018'
+
+export const CORD_CREDENTIAL_IRI_PREFIX = 'cred:cord:'

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -82,7 +82,7 @@ export function fromCredential(
     }
   }
 
-  const evidence = evidenceIds.map((leg) => leg.documentHash)
+  const evidence = evidenceIds.map((e) => e.identifier)
 
   const proof: Proof[] = []
 

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -1,0 +1,136 @@
+/**A
+ * @packageDocumentation////////////////////////////////////////////////////////
+ * @module VCExport
+ */
+
+//import { decodeAddress } from '@polkadot/keyring'
+//import { u8aToHex } from '@polkadot/util'
+import type { AnyJson } from '@polkadot/types/types'
+import { Content } from '@cord.network/modules'
+import type { IDocument, ISchema } from '@cord.network/types'
+import {
+  DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT,
+  DEFAULT_VERIFIABLE_CREDENTIAL_TYPE,
+  JSON_SCHEMA_TYPE,
+  CORD_ANCHORED_PROOF_TYPE,
+  CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
+  CORD_STREAM_SIGNATURE_PROOF_TYPE,
+  CORD_CREDENTIAL_CONTEXT_URL,
+  CORD_VERIFIABLE_CREDENTIAL_TYPE,
+  CORD_CREDENTIAL_IRI_PREFIX,
+} from './constants.js'
+import type {
+  CordStreamProof,
+  CredentialDigestProof,
+  CredentialSchema,
+  Proof,
+  CordStreamSignatureProof,
+  VerifiableCredential,
+} from './types.js'
+import { Identifier } from '@cord.network/utils'
+
+export function fromCredentialIRI(credentialId: string): string {
+  const idString = credentialId.startsWith(CORD_CREDENTIAL_IRI_PREFIX)
+    ? credentialId.substring(CORD_CREDENTIAL_IRI_PREFIX.length)
+    : credentialId
+  return idString
+}
+
+export function toCredentialIRI(streamId: string): string {
+  if (streamId.startsWith(CORD_CREDENTIAL_IRI_PREFIX)) {
+    return streamId
+  }
+  return CORD_CREDENTIAL_IRI_PREFIX + streamId
+}
+
+export function fromCredential(
+  input: IDocument,
+  schemaType?: ISchema
+): VerifiableCredential {
+  const {
+    contentHashes,
+    evidenceIds,
+    documentHash,
+    issuerSignature,
+    content,
+    identifier,
+  } = input
+
+  // write root hash to id
+  const id = toCredentialIRI(Identifier.uriToIdentifier(identifier))
+
+  // transform & annotate stream to be json-ld and VC conformant
+  const { credentialSubject } = Content.toJsonLD(content, false) as Record<
+    string,
+    Record<string, AnyJson>
+  >
+
+  const issuer = input.content.issuer
+
+  const issuanceDate = input.createdAt
+  const expirationDate = input.validUntil
+  // if schema is given, add as credential schema
+  let credentialSchema: CredentialSchema | undefined
+  if (schemaType) {
+    const schema = schemaType
+    credentialSchema = {
+      '@id': schema.$id,
+      '@type': JSON_SCHEMA_TYPE,
+      name: schema.title,
+      schema: schema.$schema,
+      properties: schema.properties,
+    }
+  }
+
+  const evidence = evidenceIds.map((leg) => leg.documentHash)
+
+  const proof: Proof[] = []
+
+  const VC: VerifiableCredential = {
+    '@context': [
+      DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT,
+      CORD_CREDENTIAL_CONTEXT_URL,
+    ],
+    id,
+    type: [DEFAULT_VERIFIABLE_CREDENTIAL_TYPE, CORD_VERIFIABLE_CREDENTIAL_TYPE],
+    issuer,
+    issuanceDate,
+    expirationDate,
+    credentialSubject,
+    credentialHash: documentHash,
+    evidence,
+    nonTransferable: true,
+    proof,
+    credentialSchema,
+  }
+
+  if (issuerSignature) {
+    const sSProof: CordStreamSignatureProof = {
+      type: CORD_STREAM_SIGNATURE_PROOF_TYPE,
+      proofPurpose: 'assertionMethod',
+      signature: issuerSignature?.signature,
+      challenge: documentHash,
+      verificationMethod: issuerSignature?.keyUri,
+    }
+    VC.proof.push(sSProof)
+  }
+ 
+  // add credential proof
+  const streamProof: CordStreamProof = {
+    type: CORD_ANCHORED_PROOF_TYPE,
+    proofPurpose: 'assertionMethod',
+    issuerAddress: input.content.issuer,
+  }
+  VC.proof.push(streamProof)
+
+  // add hashed properties proof
+  const cDProof: CredentialDigestProof = {
+    type: CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
+    proofPurpose: 'assertionMethod',
+    nonces: {...input.contentNonceMap},
+    contentHashes: [...contentHashes],
+  }
+  VC.proof.push(cDProof)
+
+  return VC
+}

--- a/packages/vc-export/src/index.ts
+++ b/packages/vc-export/src/index.ts
@@ -1,0 +1,10 @@
+import '@polkadot/api-augment'
+
+import type * as types from './types.js'
+export * as constants from './constants.js'
+export * as verification from './verificationUtils.js'
+export * as presentation from './presentationUtils.js'
+export { fromCredential } from './exportToVerifiableCredential.js'
+export * as vcjsSuites from './suites/index.js'
+
+export type { types }

--- a/packages/vc-export/src/presentationUtils.ts
+++ b/packages/vc-export/src/presentationUtils.ts
@@ -1,0 +1,170 @@
+/**
+ * @packageDocumentation
+ * @module PresentationUtils
+ */
+import { blake2AsHex } from '@polkadot/util-crypto'
+import jsonld from 'jsonld'
+import { SDKErrors, Crypto } from '@cord.network/utils'
+import {
+  CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
+  DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT,
+  DEFAULT_VERIFIABLEPRESENTATION_TYPE,
+  CORD_SELF_SIGNATURE_PROOF_TYPE,
+} from './constants.js'
+import type {
+  VerifiableCredential,
+  VerifiablePresentation,
+  CredentialDigestProof,
+  CordSelfSignatureProof,
+} from './types.js'
+
+import { DidDocument } from '@cord.network/types'
+
+export function makeSigningData(
+  rootHash: string,
+  challenge?: string | null
+): Uint8Array {
+  return new Uint8Array([
+    ...Crypto.coToUInt8(rootHash),
+    ...Crypto.coToUInt8(challenge),
+  ])
+}
+
+/**
+ * This proof is added to a credential to prove that revealed properties were attested in the original credential.
+ * For each property to be revealed, it contains an unsalted hash of the statement plus a nonce which is required to verify against the salted hash in the credential.
+ * Statements and nonces are mapped to each other through the unsalted hashes.
+ *
+ * @param credential [[VerifiableCredential]] object containing only the credentialSubject properties you want to reveal.
+ * @param proof The [[CredentialDigestProof]] to update.
+ * @param options Options.
+ * @param options.hasher The hashing function used to generate digests for nonce map. Should be the one used in creating the original credential.
+ * @returns Proof object that can be included in a Verifiable Credential / Verifiable Presentation's proof section.
+ */
+export async function updateCredentialDigestProof(
+  credential: VerifiableCredential,
+  proof: CredentialDigestProof,
+  options: { hasher?: Crypto.Hasher } = {}
+): Promise<CredentialDigestProof> {
+  const {
+    hasher = (value, nonce?) => blake2AsHex((nonce || '') + value, 256),
+  } = options
+
+  // recreate statement digests from partial stream to identify required nonces
+  const streamNonces = {}
+  const expanded = await jsonld.compact(credential.credentialSubject, {})
+  const statements = Object.entries(expanded).map(([key, value]) =>
+    JSON.stringify({ [key]: value })
+  )
+  if (statements.length < 1)
+    throw new Error(
+      `no statements extracted from ${JSON.stringify(
+        credential.credentialSubject
+      )}`
+    )
+  statements.forEach((stmt) => {
+    const digest = hasher(stmt)
+    if (Object.keys(proof.nonces).includes(digest)) {
+      streamNonces[digest] = proof.nonces[digest]
+    } else {
+      throw new Error(`nonce missing for ${stmt}`)
+    }
+  })
+
+  // return the proof containing nonces which can be mapped via an unsalted hash of the statement
+  return { ...proof, nonces: streamNonces }
+}
+
+/**
+ * Returns a copy of a CORD Verifiable Credential where all streams about the credential subject that are not whitelisted have been removed.
+ *
+ * @param VC The CORD Verifiable Credential as exported with the SDK utils.
+ * @param whitelist An array of properties to keep on the credential.
+ * @returns A Verifiable Credential containing the original proofs, but with non-whitelisted streams removed.
+ */
+export async function removeProperties(
+  VC: VerifiableCredential,
+  whitelist: string[]
+): Promise<VerifiableCredential> {
+  // get property names
+  const propertyNames = Object.keys(VC.credentialSubject)
+  // check whitelist
+  const unknownProps = whitelist.filter((prop) => !propertyNames.includes(prop))
+  if (unknownProps.length > 0) {
+    throw new Error(
+      `whitelisted properties ${unknownProps} do not exist on this credential`
+    )
+  }
+  // copy credential
+  const copied: VerifiableCredential = JSON.parse(JSON.stringify(VC))
+  // remove non-revealed props
+  propertyNames.forEach((key) => {
+    if (!(key.startsWith('@') || whitelist.includes(key)))
+      delete copied.credentialSubject[key]
+  })
+  // find old proof
+  let proofs = copied.proof instanceof Array ? copied.proof : [copied.proof]
+  const oldStreamsProof = proofs.filter(
+    (p): p is CredentialDigestProof =>
+      p.type === CORD_CREDENTIAL_DIGEST_PROOF_TYPE
+  )
+  if (oldStreamsProof.length !== 1)
+    throw new Error(
+      `expected exactly one proof of type ${CORD_CREDENTIAL_DIGEST_PROOF_TYPE}`
+    )
+  proofs = proofs.filter((p) => p.type !== CORD_CREDENTIAL_DIGEST_PROOF_TYPE)
+  // compute new (reduced) proof
+  proofs.push(await updateCredentialDigestProof(copied, oldStreamsProof[0]))
+  copied.proof = proofs
+  return copied
+}
+
+/**
+ * Creates a Verifiable Presentation from a CORD Verifiable Credential and allows removing properties while doing so. Does not currently sign the presentation or allow adding a challenge to be signed.
+ *
+ * @param VC The CORD Verifiable Credential as exported with the SDK utils.
+ * @param showProperties An array of properties to reveal.
+ * @returns A Verifiable Presentation containing the original VC with its proofs, but not extra signatures.
+ */
+export async function makePresentation(
+  VC: VerifiableCredential,
+  showProperties: string[],
+  creator: DidDocument,
+  keys: any,
+  challenge?: string
+): Promise<VerifiablePresentation> {
+  const copied = await removeProperties(VC, showProperties)
+
+  if (creator.uri !== VC.credentialSubject.holder) {
+    throw new SDKErrors.CreatorMissingError;
+  }
+//console.log(creator, VC.credentialSubject);
+  async function callback(data: any) {
+    return {
+    signature: keys.authentication.sign(data.data),
+    keyType: keys.authentication.type,
+    keyUri: `${creator.uri}${creator.authentication[0].id}`,
+    }
+  };
+
+  const signature = await callback({
+    data: makeSigningData(VC.credentialHash, challenge),
+    did: VC.credentialSubject.holder,
+  })
+
+  const selfSProof: CordSelfSignatureProof = {
+    challenge: challenge,
+    type: CORD_SELF_SIGNATURE_PROOF_TYPE,
+    proofPurpose: 'assertionMethod',
+    verificationMethod: signature.keyUri,
+    signature: Crypto.u8aToHex(signature.signature),
+  }
+
+  return {
+    '@context': [DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT],
+    type: [DEFAULT_VERIFIABLEPRESENTATION_TYPE],
+    verifiableCredential: copied,
+    holder: creator.uri,
+    proof: [selfSProof],
+  }
+}

--- a/packages/vc-export/src/suites/context/context.json
+++ b/packages/vc-export/src/suites/context/context.json
@@ -1,0 +1,76 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "cred": "https://www.w3.org/2018/credentials#",
+    "cordCred": "https://cord.network/contexts/credentials#",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "verificationMethod": {
+      "@id": "sec:verificationMethod",
+      "@type": "@id"
+    },
+    "publicKeyHex": {
+      "@id": "sec:publicKeyHex"
+    },
+    "proofPurpose": {
+      "@id": "sec:proofPurpose",
+      "@type": "@vocab",
+      "@context": {
+        "@vocab": "sec"
+      }
+    },
+    "CordCredential2020": {
+      "@id": "cordCred:CordCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "credentialStatus": {
+          "@id": "cordCred:credentialHash",
+          "@type": "@id"
+        },
+        "evidence": {
+          "@id": "cred:evidence",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "nonTransferable": {
+          "@id": "cred:nonTransferable",
+          "@type": "xsd:boolean"
+        }
+      }
+    },
+    "CordSignature2020": {
+      "@id": "cordCred:CordSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "signature": "sec:proofValue"
+      }
+    },
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "Credential": {
+      "@id": "cordCred:CordCredential2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "issuerAddress": "cred:issuer"
+      }
+    },
+    "CordCredentialDigest2020": {
+      "@id": "cordCred:CordCredentialDigest2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "contentHashes": {
+          "@id": "cordCred:CordCredentialDigest2020#contentHashes",
+          "@container": "@set"
+        },
+        "nonces": {
+          "@id": "cordCred:CordCredentialDigest2020#nonces",
+          "@container": "@index"
+        }
+      }
+    }
+  }
+}

--- a/packages/vc-export/src/suites/context/index.ts
+++ b/packages/vc-export/src/suites/context/index.ts
@@ -1,0 +1,4 @@
+import { CORD_CREDENTIAL_CONTEXT_URL } from '../../constants.js'
+import context from './context.json'
+
+export const validationContexts = { [CORD_CREDENTIAL_CONTEXT_URL]: context }

--- a/packages/vc-export/src/suites/documentLoader.ts
+++ b/packages/vc-export/src/suites/documentLoader.ts
@@ -1,0 +1,10 @@
+import type { RemoteDocument, Url } from 'jsonld/jsonld-spec'
+import { validationContexts } from './context/index.js'
+
+export async function documentLoader(url: Url): Promise<RemoteDocument> {
+  const context = validationContexts[url]
+  if (context)
+    return { contextUrl: undefined, documentUrl: url, document: context }
+  const vcjs = await import('@digitalbazaar/vc');
+  return vcjs.defaultDocumentLoader(url)
+}

--- a/packages/vc-export/src/suites/examples/example-vc-old.json
+++ b/packages/vc-export/src/suites/examples/example-vc-old.json
@@ -1,0 +1,56 @@
+{
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://cord.network/contexts/credentials"
+    ],
+    "type": [
+        "VerifiableCredential",
+        "CordCredential"
+    ],
+    "id": "cord:cred:0x24195dd6313c0bb560f3043f839533b54bcd32d602dd848471634b0345ec88ad",
+    "credentialSubject": {
+        "@id": "did:cord:4r1WkS3t8rbCb11H8t3tJvGVCynwDXSUBiuGB6sLRHzCLCjs",
+        "@context": {
+            "@vocab": "cord:schema:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf#"
+        },
+        "birthday": "1991-01-01",
+        "name": "Kurt",
+        "premium": true
+    },
+    "evidence": [],
+    "issuer": "did:cord:4sejigvu6STHdYmmYf2SuN92aNp8TbrsnBBDUj7tMrJ9Z3cG",
+    "issuanceDate": "2021-03-25T10:20:44.242Z",
+    "nonTransferable": true,
+    "proof": [
+        {
+            "type": "SelfSigned",
+            "proofPurpose": "assertionMethod",
+            "verificationMethod": {
+                "type": "Ed25519VerificationKey2018",
+                "publicKeyHex": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"
+            },
+            "signature": "0x00c374b5314d7192224bd620047f740c029af118eb5645a4662f76a2e3d70a877290f9a96cb9ee9ccc6c6bce24a0cf132a07edb603d0d0632f84210d528d2a7701"
+        },
+        {
+            "type": "Credential",
+            "proofPurpose": "assertionMethod",
+            "issuerAddress": "4sejigvu6STHdYmmYf2SuN92aNp8TbrsnBBDUj7tMrJ9Z3cG"
+        },
+        {
+            "type": "CredentialDigest",
+            "proofPurpose": "assertionMethod",
+            "nonces": {
+                "0xe5a099ea4f8be89227af8a5d74b0371e1c13232978c8b8edce1ecec698eb2665": "eab8a98c-0ef3-4a33-a5c7-c9821b3bec45",
+                "0x14a06c5955ebc9247c9f54b30e0f1714e6ebd54ae05ad7b16fa9a4643dff1dc2": "fda7a7d4-770c-4cae-9cd9-6deebdb3ed80",
+                "0xb102f462e4cde1b48e7936085cef1e2ab6ae4f7ca46cd3fab06074c00546a33d": "ed28443a-ec36-4a54-9caa-6bf014df257d",
+                "0xf42b46c4a7a3bad68650069bd81fdf2085c9ea02df1c27a82282e97e3f71ef8e": "adc7dc71-ab0a-45f9-a091-9f3ec1bb96c7"
+            },
+            "streamHashes": [
+                "0x0586412d7b8adf811c288211c9c704b3331bb3adb61fba6448c89453568180f6",
+                "0x3856178f49d3c379e00793125678eeb8db61cfa4ed32cd7a4b67ac8e27714fc1",
+                "0x683428497edeba0198f02a45a7015fc2c010fa75994bc1d1372349c25e793a10",
+                "0x8804cc546c4597b2ab0541dd3a6532e338b0b5b4d2458eb28b4d909a5d4caf4e"
+            ]
+        }
+    ]
+}

--- a/packages/vc-export/src/suites/index.ts
+++ b/packages/vc-export/src/suites/index.ts
@@ -1,0 +1,3 @@
+export * as suites from './suites/index.js'
+export { documentLoader } from './documentLoader.js'
+export { validationContexts } from './context/index.js'

--- a/packages/vc-export/src/suites/suites/CordAbstractSuite.ts
+++ b/packages/vc-export/src/suites/suites/CordAbstractSuite.ts
@@ -1,0 +1,91 @@
+/* eslint-disable class-methods-use-this */
+import {
+  DocumentLoader,
+  ExpansionMap,
+  purposes,
+  suites,
+} from 'jsonld-signatures'
+import type { JsonLdObj } from 'jsonld/jsonld-spec'
+import jsonld from 'jsonld'
+import type {
+  VerifiableCredential,
+  Proof,
+  IPublicKeyRecord,
+} from '../../types.js'
+import { documentLoader as defaultDocumentLoader } from '../documentLoader.js'
+import {
+  CORD_CREDENTIAL_CONTEXT_URL,
+  DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT,
+} from '../../constants.js'
+
+export default abstract class CordAbstractSuite extends suites.LinkedDataProof {
+  public readonly verificationMethod?: string | IPublicKeyRecord
+
+  constructor({
+    type,
+    verificationMethod,
+  }: {
+    type: string
+    verificationMethod?: string | IPublicKeyRecord
+  }) {
+    super({ type })
+    this.verificationMethod = verificationMethod
+  }
+
+  protected async compactProof<ProofType extends Proof>(
+    proof: JsonLdObj,
+    options: {
+      documentLoader?: DocumentLoader
+      expansionMap?: ExpansionMap
+      [key: string]: unknown
+    }
+  ): Promise<ProofType> {
+    const { documentLoader = defaultDocumentLoader, expansionMap } = options
+    return jsonld.compact(proof, CORD_CREDENTIAL_CONTEXT_URL, {
+      documentLoader,
+      expansionMap,
+      compactToRelative: false,
+    }) as Promise<ProofType>
+  }
+
+  protected async compactDoc(
+    document: JsonLdObj,
+    options: {
+      documentLoader?: DocumentLoader
+      expansionMap?: ExpansionMap
+      [key: string]: unknown
+    }
+  ): Promise<VerifiableCredential> {
+    const { documentLoader = defaultDocumentLoader, expansionMap } = options
+    return jsonld.compact(
+      document,
+      [DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT, CORD_CREDENTIAL_CONTEXT_URL],
+      { documentLoader, expansionMap, compactToRelative: false }
+    ) as Promise<VerifiableCredential>
+  }
+
+  public async matchProof(options: {
+    proof: JsonLdObj
+    document?: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<boolean> {
+    const { proof } = options
+    const compact = await this.compactProof(proof, options)
+    const type = compact['@type'] || compact.type
+    return type instanceof Array ? type.includes(this.type) : type === this.type
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async createProof(options: {
+    document: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<never> {
+    throw new Error(
+      'Credential issuance through vc-js is not supported. For credential issuance, use @cordnetwork/sdk and export your CORD credential to a VC representation using @cordnetwork/vc-export'
+    )
+  }
+}

--- a/packages/vc-export/src/suites/suites/CordAnchoredSuite.ts
+++ b/packages/vc-export/src/suites/suites/CordAnchoredSuite.ts
@@ -1,0 +1,78 @@
+/* eslint-disable max-classes-per-file */
+import { ApiPromise } from '@polkadot/api'
+import { ConfigService } from '@cord.network/config'
+import type {
+  DocumentLoader,
+  ExpansionMap,
+  Proof,
+  purposes,
+  VerificationResult,
+} from 'jsonld-signatures'
+import type { JsonLdObj } from 'jsonld/jsonld-spec'
+import type { CordStreamProof } from '../../types.js'
+import { verifyStreamProof, StreamStatus } from '../../verificationUtils.js'
+import { CORD_ANCHORED_PROOF_TYPE } from '../../constants.js'
+import CordAbstractSuite from './CordAbstractSuite.js'
+
+class StreamError extends Error {
+  public readonly streamStatus: StreamStatus
+
+  constructor(message: string, streamStatus: StreamStatus) {
+    super(message)
+    this.name = 'StreamError'
+    this.streamStatus = streamStatus
+  }
+}
+
+export default class CordAnchoredSuite extends CordAbstractSuite {
+  private readonly provider: ApiPromise
+
+  constructor(options: { CordConnection: ApiPromise }) {
+    // vc-js complains when there is no verificationMethod
+    super({ type: CORD_ANCHORED_PROOF_TYPE, verificationMethod: '<none>' })
+    if (
+      !options.CordConnection ||
+      !(options.CordConnection instanceof ApiPromise)
+    )
+      throw new TypeError('CordConnection must be a Cord blockchain connection')
+    this.provider = options.CordConnection
+  }
+
+  private setConnection(): void {
+    ConfigService.set(Promise.resolve(this.provider))
+  }
+
+  public async verifyProof(options: {
+    proof: Proof
+    document: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<VerificationResult> {
+    try {
+      const { document, proof } = options
+      if (!document || typeof document !== 'object')
+        throw new TypeError('document must be a JsonLd object')
+      if (!proof || typeof proof !== 'object')
+        throw new TypeError('proof must be a JsonLd object')
+      const compactedDoc = await this.compactDoc(document, options)
+      const compactedProof = await this.compactProof<CordStreamProof>(
+        proof,
+        options
+      )
+      this.setConnection()
+      const { verified, errors, status } = await verifyStreamProof(
+        compactedDoc,
+        compactedProof
+      )
+      if (errors.length > 0)
+        return {
+          verified,
+          error: new StreamError(errors[0].message, status),
+        }
+      return { verified }
+    } catch (e: any) {
+      return { verified: false, error: e }
+    }
+  }
+}

--- a/packages/vc-export/src/suites/suites/CordIntegritySuite.ts
+++ b/packages/vc-export/src/suites/suites/CordIntegritySuite.ts
@@ -1,0 +1,55 @@
+import type {
+  DocumentLoader,
+  ExpansionMap,
+  purposes,
+  VerificationResult,
+} from 'jsonld-signatures'
+import type { JsonLdObj } from 'jsonld/jsonld-spec'
+import type { CredentialDigestProof } from '../../types.js'
+
+import { verifyCredentialDigestProof } from '../../verificationUtils.js'
+import CordAbstractSuite from './CordAbstractSuite.js'
+import { CORD_CREDENTIAL_DIGEST_PROOF_TYPE } from '../../constants.js'
+
+export default class CordIntegritySuite extends CordAbstractSuite {
+  constructor() {
+    // vc-js complains when there is no verificationMethod
+    super({
+      type: CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
+      verificationMethod: '<none>',
+    })
+  }
+
+  public async verifyProof(options: {
+    proof: JsonLdObj
+    document?: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<VerificationResult> {
+    try {
+      const { document, proof } = options
+      if (!document || typeof document !== 'object')
+        throw new TypeError('document must be a JsonLd object')
+      if (!proof || typeof proof !== 'object')
+        throw new TypeError('proof must be a JsonLd object')
+      const compactedDoc = await this.compactDoc(document, options)
+      const compactedProof = await this.compactProof<CredentialDigestProof>(
+        proof,
+        options
+      )
+      const { verified, errors } = await verifyCredentialDigestProof(
+        compactedDoc,
+        compactedProof
+      )
+      if (errors.length > 0)
+        return {
+          verified,
+          error: errors[0],
+        }
+      return { verified }
+    } catch (e: any) {
+      return { verified: false, error: e }
+    }
+  }
+}

--- a/packages/vc-export/src/suites/suites/CordSelfSignatureSuite.ts
+++ b/packages/vc-export/src/suites/suites/CordSelfSignatureSuite.ts
@@ -1,0 +1,66 @@
+import type {
+  DocumentLoader,
+  ExpansionMap,
+  purposes,
+  VerificationResult,
+} from 'jsonld-signatures'
+import type { JsonLdObj } from 'jsonld/jsonld-spec'
+import type { IPublicKeyRecord, CordSelfSignatureProof } from '../../types.js'
+import { verifySelfSignatureProof } from '../../verificationUtils.js'
+import CordAbstractSuite from './CordAbstractSuite.js'
+import { CORD_SELF_SIGNATURE_PROOF_TYPE } from '../../constants.js'
+
+export default class CordSelfSignatureSuite extends CordAbstractSuite {
+  constructor() {
+    super({
+      type: CORD_SELF_SIGNATURE_PROOF_TYPE,
+      verificationMethod: '<none>',
+    })
+  }
+
+  public async verifyProof(options: {
+    proof: JsonLdObj
+    document?: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<VerificationResult> {
+    try {
+      const { document, proof, documentLoader } = options
+      if (!document || typeof document !== 'object')
+        throw new TypeError('document must be a JsonLd object')
+      if (!proof || typeof proof !== 'object')
+        throw new TypeError('proof must be a JsonLd object')
+      const compactedDoc = await this.compactDoc(document, options)
+      const compactedProof = await this.compactProof<CordSelfSignatureProof>(
+        proof,
+        options
+      )
+      if (typeof compactedProof.verificationMethod === 'string') {
+        const dereferenced = documentLoader
+          ? await documentLoader(compactedProof.verificationMethod)
+          : undefined
+        if (!dereferenced?.document) {
+          throw new Error(
+            'verificationMethod could not be dereferenced; did you select an appropriate document loader?'
+          )
+        }
+        compactedProof.verificationMethod =
+          dereferenced.document as IPublicKeyRecord
+      }
+      // note that we currently don't check whether the public key in the proof is linked to the credential subject
+      const { verified, errors } = await verifySelfSignatureProof(
+        compactedDoc,
+        compactedProof
+      )
+      if (errors.length > 0)
+        return {
+          verified,
+          error: errors[0],
+        }
+      return { verified }
+    } catch (e: any) {
+      return { verified: false, error: e }
+    }
+  }
+}

--- a/packages/vc-export/src/suites/suites/CordStreamSignatureSuite.ts
+++ b/packages/vc-export/src/suites/suites/CordStreamSignatureSuite.ts
@@ -1,0 +1,66 @@
+import type {
+  DocumentLoader,
+  ExpansionMap,
+  purposes,
+  VerificationResult,
+} from 'jsonld-signatures'
+import type { JsonLdObj } from 'jsonld/jsonld-spec'
+import type { IPublicKeyRecord, CordStreamSignatureProof } from '../../types.js'
+import { verifyStreamSignatureProof } from '../../verificationUtils.js'
+import CordAbstractSuite from './CordAbstractSuite.js'
+import { CORD_STREAM_SIGNATURE_PROOF_TYPE } from '../../constants.js'
+
+export default class CordStreamSignatureSuite extends CordAbstractSuite {
+  constructor() {
+    super({
+      type: CORD_STREAM_SIGNATURE_PROOF_TYPE,
+      verificationMethod: '<none>',
+    })
+  }
+
+  public async verifyProof(options: {
+    proof: JsonLdObj
+    document?: JsonLdObj
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): Promise<VerificationResult> {
+    try {
+      const { document, proof, documentLoader } = options
+      if (!document || typeof document !== 'object')
+        throw new TypeError('document must be a JsonLd object')
+      if (!proof || typeof proof !== 'object')
+        throw new TypeError('proof must be a JsonLd object')
+      const compactedDoc = await this.compactDoc(document, options)
+      const compactedProof = await this.compactProof<CordStreamSignatureProof>(
+        proof,
+        options
+      )
+      if (typeof compactedProof.verificationMethod === 'string') {
+        const dereferenced = documentLoader
+          ? await documentLoader(compactedProof.verificationMethod)
+          : undefined
+        if (!dereferenced?.document) {
+          throw new Error(
+            'verificationMethod could not be dereferenced; did you select an appropriate document loader?'
+          )
+        }
+        compactedProof.verificationMethod =
+          dereferenced.document as IPublicKeyRecord
+      }
+      // note that we currently don't check whether the public key in the proof is linked to the credential subject
+      const { verified, errors } = await verifyStreamSignatureProof(
+        compactedDoc,
+        compactedProof
+      )
+      if (errors.length > 0)
+        return {
+          verified,
+          error: errors[0],
+        }
+      return { verified }
+    } catch (e: any) {
+      return { verified: false, error: e }
+    }
+  }
+}

--- a/packages/vc-export/src/suites/suites/index.ts
+++ b/packages/vc-export/src/suites/suites/index.ts
@@ -1,0 +1,4 @@
+export * as CordIntegritySuite from './CordIntegritySuite.js'
+export * as CordStreamSignatureSuite from './CordStreamSignatureSuite.js'
+export * as CordSelfignatureSuite from './CordSelfSignatureSuite.js'
+export * as CordAnchoredSuite from './CordAnchoredSuite.js'

--- a/packages/vc-export/src/suites/types/crypto-ld.d.ts
+++ b/packages/vc-export/src/suites/types/crypto-ld.d.ts
@@ -1,0 +1,1 @@
+declare module 'crypto-ld'

--- a/packages/vc-export/src/suites/types/jsonld-signatures.d.ts
+++ b/packages/vc-export/src/suites/types/jsonld-signatures.d.ts
@@ -1,0 +1,74 @@
+declare module 'jsonld-signatures' {
+  import type { JsonLdObj, RemoteDocument, Url } from 'jsonld/jsonld-spec'
+  type Proof = JsonLdObj
+  interface VerificationResult {
+    verified: boolean
+    error?: Error
+    purposeResult?: { verified: boolean; error?: Error }
+  }
+  type DocumentLoader = (url: Url) => Promise<RemoteDocument>
+  type ExpansionMap = (info: any) => any
+  interface Signer {
+    sign: ({ data }: { data: Uint8Array }) => Promise<Buffer>
+  }
+  function verify(
+    document: JsonLdObj,
+    options: {
+      suite: suites.LinkedDataProof | suites.LinkedDataProof[]
+      purpose: purposes.ProofPurpose
+      documentLoader?: DocumentLoader
+      expansionMap?: ExpansionMap
+    }
+  ): Promise<{ verified: boolean; error?: Error; results: unknown[] }>
+  function sign(
+    document: JsonLdObj,
+    options: {
+      suite: suites.LinkedDataProof | suites.LinkedDataProof[]
+      purpose: purposes.ProofPurpose
+      documentLoader?: DocumentLoader
+      expansionMap?: ExpansionMap
+    }
+  ): Promise<JsonLdObj>
+  export namespace purposes {
+    export class ProofPurpose {
+      term: string
+      date?: Date | string | number
+      maxTimestampDelta?: number
+      match(
+        proof: Proof,
+        options: {
+          document?: JsonLdObj
+          documentLoader?: DocumentLoader
+          expansionMap?: ExpansionMap
+        }
+      ): Promise<boolean>
+    }
+    export class AssertionProofPurpose extends ProofPurpose {}
+  }
+  export namespace suites {
+    abstract class LinkedDataProof {
+      type: string
+      constructor(options: { type: string })
+      abstract createProof(options: {
+        document: JsonLdObj
+        purpose?: purposes.ProofPurpose
+        documentLoader?: DocumentLoader
+        expansionMap?: ExpansionMap
+      }): Promise<Proof>
+      abstract verifyProof(options: {
+        proof: Proof
+        document?: JsonLdObj
+        purpose?: purposes.ProofPurpose
+        documentLoader?: DocumentLoader
+        expansionMap?: ExpansionMap
+      }): Promise<VerificationResult>
+      matchProof(options: {
+        proof: Proof
+        document?: JsonLdObj
+        purpose?: purposes.ProofPurpose
+        documentLoader?: DocumentLoader
+        expansionMap?: ExpansionMap
+      }): Promise<boolean>
+    }
+  }
+}

--- a/packages/vc-export/src/suites/types/vc.d.ts
+++ b/packages/vc-export/src/suites/types/vc.d.ts
@@ -1,0 +1,25 @@
+declare module '@digitalbazaar/vc' {
+  import type {
+    DocumentLoader,
+    ExpansionMap,
+    purposes,
+    suites,
+  } from 'jsonld-signatures'
+  import type { JsonLdObj } from 'jsonld/jsonld-spec'
+  const defaultDocumentLoader: DocumentLoader
+  function verifyCredential(options: {
+    credential: JsonLdObj
+    suite?: suites.LinkedDataProof | suites.LinkedDataProof[]
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+  }): { verified: boolean; results: unknown[]; error?: Error }
+  function issue(options: {
+    credential: JsonLdObj
+    suite?: suites.LinkedDataProof | suites.LinkedDataProof[]
+    purpose?: purposes.ProofPurpose
+    documentLoader?: DocumentLoader
+    expansionMap?: ExpansionMap
+    compactProof?: boolean
+  }): Promise<JsonLdObj>
+}

--- a/packages/vc-export/src/types.ts
+++ b/packages/vc-export/src/types.ts
@@ -1,0 +1,93 @@
+/**
+ * @packageDocumentation
+ * @module VCExportTypes
+ */
+import type { AnyJson } from '@polkadot/types/types'
+// import type { IDidDocumentPublicKey } from '@cord.network/modules'
+import type { ISchema, IIdentityPublicKey } from '@cord.network/types'
+import type {
+  DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT,
+  DEFAULT_VERIFIABLE_CREDENTIAL_TYPE,
+  DEFAULT_VERIFIABLEPRESENTATION_TYPE,
+  JSON_SCHEMA_TYPE,
+  CORD_ANCHORED_PROOF_TYPE,
+  CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
+  CORD_STREAM_SIGNATURE_PROOF_TYPE,
+  CORD_SELF_SIGNATURE_PROOF_TYPE,
+} from './constants.js'
+
+export interface Proof {
+  type: string
+  created?: string
+  proofPurpose?: string
+  [key: string]: any
+}
+
+export type IPublicKeyRecord = Partial<IIdentityPublicKey> &
+  Pick<IIdentityPublicKey, 'publicKeyHex' | 'type'>
+
+export interface CordStreamSignatureProof extends Proof {
+  type: typeof CORD_STREAM_SIGNATURE_PROOF_TYPE
+  verificationMethod: string | IPublicKeyRecord
+  signature: string
+}
+export interface CordStreamProof extends Proof {
+  type: typeof CORD_ANCHORED_PROOF_TYPE
+  issuerAddress: string
+}
+export interface CredentialDigestProof extends Proof {
+  type: typeof CORD_CREDENTIAL_DIGEST_PROOF_TYPE
+  // map of unsalted property digests and nonces
+  nonces: Record<string, string>
+  // salted hashes of statements in credentialSubject to allow selective disclosure.
+  contentHashes: string[]
+}
+export interface CordSelfSignatureProof extends Proof {
+  type: typeof CORD_SELF_SIGNATURE_PROOF_TYPE
+  verificationMethod: string | IPublicKeyRecord
+  signature: string
+  challenge?: string
+}
+
+export interface CredentialSchema {
+  '@id': string
+  '@type': typeof JSON_SCHEMA_TYPE
+  schema: ISchema['$schema']
+  properties: ISchema['properties']
+  modelVersion?: string
+  name?: string
+  author?: string
+  authored?: string
+  proof?: Proof
+}
+
+export interface VerifiableCredential {
+  '@context': [typeof DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT, ...string[]]
+  // the credential types, which declare what data to expect in the credential
+  id: string
+  type: [typeof DEFAULT_VERIFIABLE_CREDENTIAL_TYPE, ...string[]]
+  // the entity that issued the credential
+  issuer: string
+  // when the credential was issued
+  issuanceDate: string
+  // when the credential will expire
+  expirationDate: string
+  // streams about the subjects of the credential
+  credentialSubject: Record<string, AnyJson>
+  // rootHash  of the credential
+  credentialHash: string
+  // Ids / digests of streams that empower the issuer to provide judegment
+  evidence: string[]
+  // digital proof that makes the credential tamper-evident
+  proof: Proof | Proof[]
+  nonTransferable?: boolean
+  credentialSchema?: CredentialSchema
+}
+
+export interface VerifiablePresentation {
+  '@context': [typeof DEFAULT_VERIFIABLE_CREDENTIAL_CONTEXT, ...string[]]
+  type: [typeof DEFAULT_VERIFIABLEPRESENTATION_TYPE, ...string[]]
+  verifiableCredential: VerifiableCredential | VerifiableCredential[]
+  holder?: string
+  proof: Proof | Proof[]
+}

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -1,0 +1,282 @@
+/**
+ * @packageDocumentation
+ * @module VerificationUtils
+ */
+
+import { ConfigService, DidResourceUri, Stream } from "@cord.network/sdk"
+import { CORD_ANCHORED_PROOF_TYPE, CORD_CREDENTIAL_DIGEST_PROOF_TYPE, CORD_SELF_SIGNATURE_PROOF_TYPE, CORD_STREAM_SIGNATURE_PROOF_TYPE } from "./constants"
+import { fromCredentialIRI } from "./exportToVerifiableCredential"
+import { CordSelfSignatureProof, CordStreamProof, CordStreamSignatureProof, CredentialDigestProof, VerifiableCredential } from "./types"
+import { Crypto } from "@cord.network/utils"
+import { u8aConcat, hexToU8a, u8aToHex } from '@polkadot/util'
+//import { blake2AsHex } from '@polkadot/util-crypto'
+import { makeSigningData } from "./presentationUtils"
+import { signatureFromJson, verifyDidSignature } from "@cord.network/did"
+import type { AnyJson } from '@polkadot/types/types'
+
+export interface VerificationResult {
+  verified: boolean
+  errors: Error[]
+}
+
+export enum StreamStatus {
+  valid = 'valid',
+  invalid = 'invalid',
+  revoked = 'revoked',
+  unknown = 'unknown',
+}
+
+export interface StreamVerificationResult extends VerificationResult {
+  status: StreamStatus
+}
+
+const CREDENTIAL_MALFORMED_ERROR = (reason: string): Error =>
+  new Error(`Credential malformed: ${reason}`)
+
+const PROOF_MALFORMED_ERROR = (reason: string): Error =>
+  new Error(`Proof malformed: ${reason}`)
+
+/**
+ * Verifies a CORD credential proof by querying data from the CORD blockchain.
+ * This includes querying the CORD blockchain with the credential id, which returns an credential record if attested.
+ * This record is then compared against issuer address and delegation id (the latter of which is taken directly from the credential).
+ *
+ * @param credential Verifiable Credential to verify proof against.
+ * @param proof CORD self signed proof object.
+ * @returns Object indicating whether proof could be verified.
+ */
+export async function verifyStreamProof(
+  credential: VerifiableCredential,
+  proof: CordStreamProof
+): Promise<StreamVerificationResult> {
+  let status: StreamStatus = StreamStatus.unknown
+  try {
+    // check proof
+    const type = proof['@type'] || proof.type
+    if (type !== CORD_ANCHORED_PROOF_TYPE)
+      throw new Error('Proof type mismatch')
+    const { issuerAddress } = proof
+    if (typeof issuerAddress !== 'string' || !issuerAddress)
+      throw PROOF_MALFORMED_ERROR('issuer address not understood')
+    if (issuerAddress !== credential.issuer)
+      throw PROOF_MALFORMED_ERROR('credential issuer address is not matching')
+
+    if (typeof credential.id !== 'string' || !credential.id)
+      throw CREDENTIAL_MALFORMED_ERROR(
+        'stream id (=stream hash) missing / invalid'
+      )
+    const streamId = fromCredentialIRI(credential.id)
+
+    const api = await ConfigService.get('api');
+    // query on-chain data by credential id (= stream root hash)
+    const onChainData = await api.query.stream.streams(streamId)
+    const onChain = Stream.fromChain(onChainData, streamId);
+    // if not found, credential has not been attested, proof is invalid
+    if (!onChain) {
+      status = StreamStatus.invalid
+      throw new Error(`credential for credential with id ${streamId} not found`)
+    }
+    // if issuer data on proof does not correspond to data on chain, proof is incorrect
+    if (onChain.issuer !== issuerAddress) {
+      status = StreamStatus.invalid
+      throw new Error(
+        `proof not matching on-chain data: proof ${{
+          issuer: issuerAddress,
+        }}`
+      )
+    }
+
+    // if documentHash on credential does not correspond to data on chain, proof is incorrect
+    if (onChain.streamHash !== credential.credentialHash)
+      throw new Error(
+        `credential hash is not matching on-chain data: proof ${{
+          hash: credential.credentialHash,
+        }}`
+      )
+
+    // if proof data is valid but credential is flagged as revoked, credential is no longer valid
+    if (onChain.revoked) {
+      status = StreamStatus.revoked
+      throw new Error('credential revoked')
+    }
+  } catch (e) {
+    return {
+      verified: false,
+      errors: [e as Error],
+      status,
+    }
+  }
+  return { verified: true, errors: [], status: StreamStatus.valid }
+}
+
+function jsonLDcontents(
+  content: Record<string, AnyJson>,
+  vocabulary: string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+ 
+  Object.entries(content || {}).forEach(([key, value]) => {
+    result[vocabulary + key] = value
+  })
+  return result
+}
+
+function makeStatementsJsonLD(content: Record<string, AnyJson>): string[] {
+  const vocabObj = content['@context']
+  const vocabulary = vocabObj ? vocabObj['@vocab'] : undefined;
+  if (!vocabulary) throw new Error('Schema Identifier Missing')
+  delete content['@context'];
+  const normalized = jsonLDcontents(content, vocabulary)
+  return Object.entries(normalized).map(([key, value]) =>
+    JSON.stringify({ [key]: value })
+  )
+}
+
+
+export async function verifyCredentialDigestProof(
+  credential: VerifiableCredential,
+  proof: CredentialDigestProof,
+  options: { hasher?: Crypto.Hasher } = {}
+): Promise<VerificationResult> {
+  try {
+    // check proof
+    const type = proof['@type'] ?? proof.type
+    if (type !== CORD_CREDENTIAL_DIGEST_PROOF_TYPE)
+      throw new Error('Proof type mismatch')
+    if (typeof proof.nonces !== 'object') {
+      throw  PROOF_MALFORMED_ERROR('Proof must contain object "nonces"')
+    }
+    if (typeof credential.credentialSubject !== 'object')
+      throw CREDENTIAL_MALFORMED_ERROR('Credential subject missing')
+
+    // 1: check credential digest against credential contents & claim property hashes in proof
+    // collect hashes from hash array, legitimations & delegationId
+    const defaults = { canonicalisation: makeStatementsJsonLD }
+    const canonicalisation = defaults.canonicalisation
+ 
+    const hashes = proof.contentHashes
+    // convert hex hashes to byte arrays & concatenate
+    const concatenated = u8aConcat(
+      ...hashes.map((hexHash) => hexToU8a(hexHash))
+    )
+    const rootHash = Crypto.hash(concatenated)
+
+    // throw if root hash does not match expected (=id)
+    const expectedRootHash = credential.credentialHash
+    if (expectedRootHash !== u8aToHex(rootHash)) {
+      throw new Error(`Computed root hash does not match expected ${expectedRootHash} != ${u8aToHex(rootHash)}`)
+    }
+    // 2: check individual properties against claim hashes in proof
+    // expand credentialSubject keys by compacting with empty context credential to produce statements
+    const statements = canonicalisation(credential.credentialSubject)
+    
+  const { nonces } = proof
+  // iterate over statements to produce salted hashes
+  const hashed = Crypto.hashStatements(statements, { ...options, nonces })
+  const digestsInProof = Object.keys(nonces)
+  const result = hashed.reduce<{
+      verified: boolean
+      errors: Error[]
+    }>(
+      (status, { saltedHash, statement, digest, nonce }) => {
+        // check if the statement digest was contained in the proof and mapped it to a nonce
+        if (!digestsInProof.includes(digest) || !nonce) {
+          status.errors.push(PROOF_MALFORMED_ERROR(
+            `Proof contains no digest for statement ${statement} - ${digestsInProof} ${digest}`
+          ))
+          return { ...status, verified: false }
+        }
+        // check if the hash is whitelisted in the proof
+        if (!proof.contentHashes.includes(saltedHash)) {
+          status.errors.push(
+            new Error('proof missing hash')
+          )
+          return { ...status, verified: false }
+        }
+        return status
+      },
+      { verified: true, errors: [] }
+    )
+    return result;
+  } catch(error) {
+    return { verified: false, errors: [new Error(`${error}`)]}
+  }
+}
+
+export async function verifyStreamSignatureProof(
+    credential: VerifiableCredential,
+    proof: CordStreamSignatureProof
+): Promise<VerificationResult> {
+  const result: VerificationResult = { verified: true, errors: [] }
+  try {
+    // check proof
+    const type = proof['@type'] ?? proof.type
+    if (type !== CORD_STREAM_SIGNATURE_PROOF_TYPE)
+      throw new Error('Proof type mismatch')
+    if (!proof.signature) throw PROOF_MALFORMED_ERROR('signature missing')
+    /*TODO: for now, makePresentation takes just one VC. Think more on what should be verified. */ 
+    const signingData = makeSigningData(proof.challenge)
+
+    const proofJson = {
+      keyUri: proof.verificationMethod as DidResourceUri,
+      signature: proof.signature,
+    }
+    try {
+    await verifyDidSignature({
+      ...signatureFromJson(proofJson),
+      message: signingData,
+      // check if credential owner matches signer
+      expectedSigner: credential.issuer as DidResourceUri,
+      expectedVerificationMethod: 'authentication'
+    })
+  } catch (err) {
+    result.verified = false;
+    result.errors.push(err as  Error);
+  }
+  } catch (e) {
+    result.verified = false
+    result.errors = [e as Error]
+    return result
+  }
+  return result;
+}
+
+
+export async function verifySelfSignatureProof(
+  credential: VerifiableCredential,
+  proof: CordSelfSignatureProof,
+  challenge?: string
+ ) : Promise<VerificationResult> {
+  const result: VerificationResult = { verified: true, errors: [] }
+  try {
+    // check proof
+    const type = proof['@type'] ?? proof.type
+    if (type !== CORD_SELF_SIGNATURE_PROOF_TYPE)
+      throw new Error('Proof type mismatch')
+    if (!proof.signature) throw PROOF_MALFORMED_ERROR('signature missing')
+    /*TODO: for now, makePresentation takes just one VC. Think more on what should be verified. */ 
+    const signingData = makeSigningData(credential.credentialHash, proof.challenge)
+
+    const proofJson = {
+      keyUri: proof.verificationMethod as DidResourceUri,
+      signature: proof.signature,
+    }
+    try {
+    await verifyDidSignature({
+      ...signatureFromJson(proofJson),
+      message: signingData,
+      // check if credential owner matches signer
+      expectedSigner: credential.credentialSubject.holder as `did:cord:3${string}#${string}`,
+      expectedVerificationMethod: 'authentication'
+    })
+  } catch (err) {
+    result.verified = false;
+    result.errors.push(err as  Error);
+  }
+  } catch (e) {
+    result.verified = false
+    result.errors = [e as Error]
+    return result
+  }
+  return result;
+}

--- a/packages/vc-export/src/verificationUtils.ts
+++ b/packages/vc-export/src/verificationUtils.ts
@@ -120,11 +120,12 @@ function jsonLDcontents(
 }
 
 function makeStatementsJsonLD(content: Record<string, AnyJson>): string[] {
+  const temp_content: Record<string, AnyJson> = { ...content };
   const vocabObj = content['@context']
   const vocabulary = vocabObj ? vocabObj['@vocab'] : undefined;
   if (!vocabulary) throw new Error('Schema Identifier Missing')
-  delete content['@context'];
-  const normalized = jsonLDcontents(content, vocabulary)
+  delete temp_content['@context'];
+  const normalized = jsonLDcontents(temp_content, vocabulary)
   return Object.entries(normalized).map(([key, value]) =>
     JSON.stringify({ [key]: value })
   )

--- a/packages/vc-export/tsconfig.build.json
+++ b/packages/vc-export/tsconfig.build.json
@@ -1,0 +1,17 @@
+  {
+  "extends": "../../tsconfig.build.json",
+
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./lib/cjs"
+  },
+
+  "include": [
+    "src/**/*.ts", "src/**/*.js"
+  ],
+
+  "exclude": [
+    "coverage",
+    "**/*.spec.ts",
+  ]
+}

--- a/packages/vc-export/tsconfig.esm.json
+++ b/packages/vc-export/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./lib/esm"
+  }
+}

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -16,7 +16,7 @@
       "packages/type-definitions/src/index.ts",
       "packages/modules/src/index.ts",
       // "packages/messaging/src/index.ts",
-      // "packages/vc-export/src/index.ts",
+      "packages/vc-export/src/index.ts",
       "packages/sdk/src/index.ts"
     ],
     "out": "docs/api",

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,12 +603,52 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@cord.network/vc-export@workspace:packages/vc-export":
+  version: 0.0.0-use.local
+  resolution: "@cord.network/vc-export@workspace:packages/vc-export"
+  dependencies:
+    "@cord.network/modules": "workspace:*"
+    "@cord.network/network": "workspace:*"
+    "@cord.network/types": "workspace:*"
+    "@cord.network/utils": "workspace:*"
+    "@digitalbazaar/vc": ^6.0.1
+    "@types/jsonld": 1.5.1
+    bip39: ^3.1.0
+    jsonld: ^8.1.1
+    jsonld-signatures: ^5.0.0
+    rimraf: ^3.0.2
+    typescript: ^4.8.3
+  languageName: unknown
+  linkType: soft
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
+"@digitalbazaar/http-client@npm:^3.2.0":
+  version: 3.4.0
+  resolution: "@digitalbazaar/http-client@npm:3.4.0"
+  dependencies:
+    ky: ^0.33.3
+    ky-universal: ^0.11.0
+    undici: ^5.21.2
+  checksum: ca49f7b0cbedc9494101179d3d51266a902fcbf883cb77ac727b46978844160962ea4aa7898f54c6385799c4eb83e1798c4ecad07168435d7e6f9ac5038bc155
+  languageName: node
+  linkType: hard
+
+"@digitalbazaar/vc@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@digitalbazaar/vc@npm:6.0.1"
+  dependencies:
+    credentials-context: ^2.0.0
+    jsonld: ^8.1.0
+    jsonld-signatures: ^11.0.0
+  checksum: b57794367a6045e489ce0a31cd7a54e520fab12babedc03edb704af521f2cfac5b300bb06847495066ca19e7e89d4383f4e7c8362021c858552aeb1ad5bf0d9d
   languageName: node
   linkType: hard
 
@@ -1198,6 +1238,13 @@ __metadata:
   version: 1.2.0
   resolution: "@noble/hashes@npm:1.2.0"
   checksum: 8ca080ce557b8f40fb2f78d3aedffd95825a415ac8e13d7ffe3643f8626a8c2d99a3e5975b555027ac24316d8b3c02a35b8358567c0c23af681e6573602aa434
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "@noble/hashes@npm:1.3.0"
+  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
   languageName: node
   linkType: hard
 
@@ -1984,6 +2031,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsonld@npm:1.5.1":
+  version: 1.5.1
+  resolution: "@types/jsonld@npm:1.5.1"
+  checksum: 592ca140dba64db5063855cef12e9abdd6e87a3bf22af2c034aadb2786ed89d703933f887564b1247cff1a5781b733243944283c6a3c767e9ec3433232e6b4d4
+  languageName: node
+  linkType: hard
+
 "@types/node-fetch@npm:^2.6.2":
   version: 2.6.4
   resolution: "@types/node-fetch@npm:2.6.4"
@@ -2440,6 +2494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: ^5.0.0
+  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -2539,7 +2602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
+"ajv@npm:^6.10.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -2760,12 +2823,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:^0.2.6":
+"asn1@npm:^0.2.6, asn1@npm:~0.2.3":
   version: 0.2.6
   resolution: "asn1@npm:0.2.6"
   dependencies:
     safer-buffer: ~2.1.0
   checksum: 39f2ae343b03c15ad4f238ba561e626602a3de8d94ae536c46a4a93e69578826305366dc09fbb9b56aec39b4982a463682f259c38e59f6fa380cd72cd61e493d
+  languageName: node
+  linkType: hard
+
+"assert-plus@npm:1.0.0, assert-plus@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "assert-plus@npm:1.0.0"
+  checksum: 19b4340cb8f0e6a981c07225eacac0e9d52c2644c080198765d63398f0075f83bbc0c8e95474d54224e297555ad0d631c1dcd058adb1ddc2437b41a6b424ac64
   languageName: node
   linkType: hard
 
@@ -2794,6 +2864,20 @@ __metadata:
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
   checksum: 20eb47b3cefd7db027b9bbb993c658abd36d4edd3fe1060e83699a03ee275b0c9b216cc076ff3f2db29073225fb70e7613987af14269ac1fe2a19803ccc97f1a
+  languageName: node
+  linkType: hard
+
+"aws-sign2@npm:~0.7.0":
+  version: 0.7.0
+  resolution: "aws-sign2@npm:0.7.0"
+  checksum: b148b0bb0778098ad8cf7e5fc619768bcb51236707ca1d3e5b49e41b171166d8be9fdc2ea2ae43d7decf02989d0aaa3a9c4caa6f320af95d684de9b548a71525
+  languageName: node
+  linkType: hard
+
+"aws4@npm:^1.8.0":
+  version: 1.12.0
+  resolution: "aws4@npm:1.12.0"
+  checksum: 68f79708ac7c335992730bf638286a3ee0a645cf12575d557860100767c500c08b30e24726b9f03265d74116417f628af78509e1333575e9f8d52a80edfe8cbc
   languageName: node
   linkType: hard
 
@@ -2881,6 +2965,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-x@npm:^3.0.2":
+  version: 3.0.9
+  resolution: "base-x@npm:3.0.9"
+  dependencies:
+    safe-buffer: ^5.0.1
+  checksum: 957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -2888,12 +2981,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcrypt-pbkdf@npm:^1.0.2":
+"base64url-universal@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "base64url-universal@npm:1.1.0"
+  dependencies:
+    base64url: ^3.0.0
+  checksum: ccc38572082df79ba845ddb84cc064b2e16490687fb1d138ef0e64f0e14d1ca2800b1cbe976f3d59ce79dc31a6cb3985aec7b64e295a8001becbf032bac26276
+  languageName: node
+  linkType: hard
+
+"base64url@npm:^3.0.0, base64url@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "base64url@npm:3.0.1"
+  checksum: a77b2a3a526b3343e25be424de3ae0aa937d78f6af7c813ef9020ef98001c0f4e2323afcd7d8b2d2978996bf8c42445c3e9f60c218c622593e5fdfd54a3d6e18
+  languageName: node
+  linkType: hard
+
+"bcrypt-pbkdf@npm:^1.0.0, bcrypt-pbkdf@npm:^1.0.2":
   version: 1.0.2
   resolution: "bcrypt-pbkdf@npm:1.0.2"
   dependencies:
     tweetnacl: ^0.14.3
   checksum: 4edfc9fe7d07019609ccf797a2af28351736e9d012c8402a07120c4453a3b789a15f2ee1530dc49eee8f7eb9379331a8dd4b3766042b9e502f74a68e7f662291
+  languageName: node
+  linkType: hard
+
+"bip39@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "bip39@npm:3.1.0"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+  checksum: 1224e763ffc6b097052ed8abd57f0e521ad6d31f1645be0d0a15f4417c13f8461f00e47e9cf7c8c784bd533f4fb1ee3ab020f258c7df45ee5dc722b4b0336cfc
   languageName: node
   linkType: hard
 
@@ -3051,6 +3169,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bs58@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "bs58@npm:4.0.1"
+  dependencies:
+    base-x: ^3.0.2
+  checksum: b3c5365bb9e0c561e1a82f1a2d809a1a692059fae016be233a6127ad2f50a6b986467c3a50669ce4c18929dcccb297c5909314dd347a25a68c21b68eb3e95ac2
+  languageName: node
+  linkType: hard
+
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -3115,6 +3242,15 @@ __metadata:
   version: 0.0.6
   resolution: "buildcheck@npm:0.0.6"
   checksum: ad61759dc98d62e931df2c9f54ccac7b522e600c6e13bdcfdc2c9a872a818648c87765ee209c850f022174da4dd7c6a450c00357c5391705d26b9c5807c2a076
+  languageName: node
+  linkType: hard
+
+"busboy@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "busboy@npm:1.6.0"
+  dependencies:
+    streamsearch: ^1.1.0
+  checksum: 32801e2c0164e12106bf236291a00795c3c4e4b709ae02132883fe8478ba2ae23743b11c5735a0aae8afe65ac4b6ca4568b91f0d9fed1fdbc32ede824a73746e
   languageName: node
   linkType: hard
 
@@ -3186,6 +3322,20 @@ __metadata:
   version: 1.0.30001489
   resolution: "caniuse-lite@npm:1.0.30001489"
   checksum: 94585a351fd7661b855c83eace474db0ee5a617159b46f2eff1f6fe4b85d7a205418471fdec8cf5cd647a7f79958706d5e664c0bbf3c7c09118b35db9bb95a1b
+  languageName: node
+  linkType: hard
+
+"canonicalize@npm:^1.0.1":
+  version: 1.0.8
+  resolution: "canonicalize@npm:1.0.8"
+  checksum: c31ea64160171bbcd7ac0dc081058fbcff055410a1d532d7b3959e7b02a3001c5d5f4f8bad934ed5246eafc9a928d333cc0c29846c16fb6d0be97b8fb444de3c
+  languageName: node
+  linkType: hard
+
+"caseless@npm:~0.12.0":
+  version: 0.12.0
+  resolution: "caseless@npm:0.12.0"
+  checksum: b43bd4c440aa1e8ee6baefee8063b4850fd0d7b378f6aabc796c9ec8cb26d27fb30b46885350777d9bd079c5256c0e1329ad0dc7c2817e0bb466810ebb353751
   languageName: node
   linkType: hard
 
@@ -3364,7 +3514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -3438,6 +3588,13 @@ __metadata:
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
+  languageName: node
+  linkType: hard
+
+"core-util-is@npm:1.0.2":
+  version: 1.0.2
+  resolution: "core-util-is@npm:1.0.2"
+  checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
   languageName: node
   linkType: hard
 
@@ -3522,6 +3679,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"credentials-context@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "credentials-context@npm:2.0.0"
+  checksum: c5ba6d257ef2fb1c21399238f5b1e0b2f7622b1f496f499edbac2d2e0faba40ebc06e0c5acee4bb2fbe712abfa3cbebdcc152f4bcf5a7481430f2731f2c514db
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -3549,6 +3713,22 @@ __metadata:
     randombytes: ^2.0.0
     randomfill: ^1.0.3
   checksum: c1609af82605474262f3eaa07daa0b2140026bd264ab316d4bf1170272570dbe02f0c49e29407fe0d3634f96c507c27a19a6765fb856fed854a625f9d15618e2
+  languageName: node
+  linkType: hard
+
+"crypto-ld@npm:^3.7.0":
+  version: 3.9.0
+  resolution: "crypto-ld@npm:3.9.0"
+  dependencies:
+    base64url-universal: ^1.0.1
+    bs58: ^4.0.1
+    node-forge: ~0.10.0
+    semver: ^6.2.0
+    sodium-native: ^3.2.0
+  dependenciesMeta:
+    sodium-native:
+      optional: true
+  checksum: d1d24e946d0b35bfe7b063d596e19dbaebe2420b7ec4a03b21b81bf7e05ce7e8ec6c85b1b84f87cb684f96789dcccf984af8f12e41c69d0dd5a9299ef66c11f7
   languageName: node
   linkType: hard
 
@@ -3582,6 +3762,15 @@ __metadata:
     es5-ext: ^0.10.50
     type: ^1.0.1
   checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
+  languageName: node
+  linkType: hard
+
+"dashdash@npm:^1.12.0":
+  version: 1.14.1
+  resolution: "dashdash@npm:1.14.1"
+  dependencies:
+    assert-plus: ^1.0.0
+  checksum: 3634c249570f7f34e3d34f866c93f866c5b417f0dd616275decae08147dcdf8fccfaa5947380ccfb0473998ea3a8057c0b4cd90c875740ee685d0624b2983598
   languageName: node
   linkType: hard
 
@@ -3799,6 +3988,16 @@ __metadata:
   dependencies:
     webidl-conversions: ^5.0.0
   checksum: d638e9cb05c52999f1b2eb87c374b03311ea5b1d69c2f875bc92da73e17db60c12142b45c950228642ff7f845c536b65305483350d080df59003a653da80b691
+  languageName: node
+  linkType: hard
+
+"ecc-jsbn@npm:~0.1.1":
+  version: 0.1.2
+  resolution: "ecc-jsbn@npm:0.1.2"
+  dependencies:
+    jsbn: ~0.1.0
+    safer-buffer: ^2.1.0
+  checksum: 22fef4b6203e5f31d425f5b711eb389e4c6c2723402e389af394f8411b76a488fa414d309d866e2b577ce3e8462d344205545c88a8143cc21752a5172818888a
   languageName: node
   linkType: hard
 
@@ -4428,6 +4627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.7":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -4502,6 +4708,27 @@ __metadata:
   dependencies:
     type: ^2.7.2
   checksum: ef481f9ef45434d8c867cfd09d0393b60945b7c8a1798bedc4514cb35aac342ccb8d8ecb66a513e6a2b4ec1e294a338e3124c49b29736f8e7c735721af352c31
+  languageName: node
+  linkType: hard
+
+"extend@npm:~3.0.2":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
+  languageName: node
+  linkType: hard
+
+"extsprintf@npm:1.3.0":
+  version: 1.3.0
+  resolution: "extsprintf@npm:1.3.0"
+  checksum: cee7a4a1e34cffeeec18559109de92c27517e5641991ec6bab849aa64e3081022903dd53084f2080d0d2530803aa5ee84f1e9de642c365452f9e67be8f958ce2
+  languageName: node
+  linkType: hard
+
+"extsprintf@npm:^1.2.0":
+  version: 1.4.1
+  resolution: "extsprintf@npm:1.4.1"
+  checksum: a2f29b241914a8d2bad64363de684821b6b1609d06ae68d5b539e4de6b28659715b5bea94a7265201603713b7027d35399d10b0548f09071c5513e65e8323d33
   languageName: node
   linkType: hard
 
@@ -4655,6 +4882,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"forever-agent@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "forever-agent@npm:0.6.1"
+  checksum: 766ae6e220f5fe23676bb4c6a99387cec5b7b62ceb99e10923376e27bfea72f3c3aeec2ba5f45f3f7ba65d6616965aa7c20b15002b6860833bb6e394dea546a8
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^3.0.0":
   version: 3.0.1
   resolution: "form-data@npm:3.0.1"
@@ -4663,6 +4897,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:~2.3.2":
+  version: 2.3.3
+  resolution: "form-data@npm:2.3.3"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.6
+    mime-types: ^2.1.12
+  checksum: 10c1780fa13dbe1ff3100114c2ce1f9307f8be10b14bf16e103815356ff567b6be39d70fc4a40f8990b9660012dc24b0f5e1dde1b6426166eb23a445ba068ca3
   languageName: node
   linkType: hard
 
@@ -4837,6 +5082,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"getpass@npm:^0.1.1":
+  version: 0.1.7
+  resolution: "getpass@npm:0.1.7"
+  dependencies:
+    assert-plus: ^1.0.0
+  checksum: ab18d55661db264e3eac6012c2d3daeafaab7a501c035ae0ccb193c3c23e9849c6e29b6ac762b9c2adae460266f925d55a3a2a3a3c8b94be2f222df94d70c046
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -4957,6 +5211,23 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
+  languageName: node
+  linkType: hard
+
+"har-schema@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "har-schema@npm:2.0.0"
+  checksum: d8946348f333fb09e2bf24cc4c67eabb47c8e1d1aa1c14184c7ffec1140a49ec8aa78aa93677ae452d71d5fc0fdeec20f0c8c1237291fc2bcb3f502a5d204f9b
+  languageName: node
+  linkType: hard
+
+"har-validator@npm:~5.1.3":
+  version: 5.1.5
+  resolution: "har-validator@npm:5.1.5"
+  dependencies:
+    ajv: ^6.12.3
+    har-schema: ^2.0.0
+  checksum: b998a7269ca560d7f219eedc53e2c664cd87d487e428ae854a6af4573fc94f182fe9d2e3b92ab968249baec7ebaf9ead69cf975c931dc2ab282ec182ee988280
   languageName: node
   linkType: hard
 
@@ -5103,6 +5374,17 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
+  languageName: node
+  linkType: hard
+
+"http-signature@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "http-signature@npm:1.2.0"
+  dependencies:
+    assert-plus: ^1.0.0
+    jsprim: ^1.2.2
+    sshpk: ^1.7.0
+  checksum: 3324598712266a9683585bb84a75dec4fd550567d5e0dd4a0fff6ff3f74348793404d3eeac4918fa0902c810eeee1a86419e4a2e92a164132dfe6b26743fb47c
   languageName: node
   linkType: hard
 
@@ -5479,7 +5761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typedarray@npm:^1.0.0":
+"is-typedarray@npm:^1.0.0, is-typedarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
@@ -5513,6 +5795,13 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
+  languageName: node
+  linkType: hard
+
+"isstream@npm:~0.1.2":
+  version: 0.1.2
+  resolution: "isstream@npm:0.1.2"
+  checksum: 1eb2fe63a729f7bdd8a559ab552c69055f4f48eb5c2f03724430587c6f450783c8f1cd936c1c952d0a927925180fcc892ebd5b174236cf1065d4bd5bdb37e963
   languageName: node
   linkType: hard
 
@@ -6180,6 +6469,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsbn@npm:~0.1.0":
+  version: 0.1.1
+  resolution: "jsbn@npm:0.1.1"
+  checksum: e5ff29c1b8d965017ef3f9c219dacd6e40ad355c664e277d31246c90545a02e6047018c16c60a00f36d561b3647215c41894f5d869ada6908a2e0ce4200c88f2
+  languageName: node
+  linkType: hard
+
 "jsdoc-type-pratt-parser@npm:~2.2.3":
   version: 2.2.5
   resolution: "jsdoc-type-pratt-parser@npm:2.2.5"
@@ -6257,6 +6553,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
+  languageName: node
+  linkType: hard
+
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -6264,7 +6567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stringify-safe@npm:^5.0.1":
+"json-stringify-safe@npm:^5.0.1, json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
   checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
@@ -6298,6 +6601,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonld-signatures@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "jsonld-signatures@npm:11.1.0"
+  dependencies:
+    jsonld: ^8.0.0
+    security-context: ^4.0.0
+    serialize-error: ^8.1.0
+  checksum: d3f0c7e5592ddab760a75d316fbb582ff2386e6712d5e1590f5aab0f4cec4a2619b85dfdae7bc117fd0a7573af5b3a180f2d0af2ecdeeefc8aaa4182b5a0ae32
+  languageName: node
+  linkType: hard
+
+"jsonld-signatures@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "jsonld-signatures@npm:5.2.0"
+  dependencies:
+    base64url: ^3.0.1
+    crypto-ld: ^3.7.0
+    jsonld: ^2.0.2
+    node-forge: ^0.10.0
+    security-context: ^4.0.0
+    serialize-error: ^5.0.0
+  checksum: 642370e1375fc3c4e33f9678294828737465163b29141273de64bb3785d28927367805ebfd8ca3097338924d315c9126055e06a0311d45301f214f7aaaefdb83
+  languageName: node
+  linkType: hard
+
+"jsonld@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "jsonld@npm:2.0.2"
+  dependencies:
+    canonicalize: ^1.0.1
+    lru-cache: ^5.1.1
+    rdf-canonize: ^1.0.2
+    request: ^2.88.0
+    semver: ^6.3.0
+    xmldom: 0.1.19
+  checksum: 2aa30e6d624dfdd0bb2152b02f95ff240059cb6b9c92e3948e9e464a0cbf414fcd0df635298f56ff05e00a76f6de3d1da814d7e45cde213a13a5998e67510333
+  languageName: node
+  linkType: hard
+
+"jsonld@npm:^8.0.0, jsonld@npm:^8.1.0, jsonld@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "jsonld@npm:8.1.1"
+  dependencies:
+    "@digitalbazaar/http-client": ^3.2.0
+    canonicalize: ^1.0.1
+    lru-cache: ^6.0.0
+    rdf-canonize: ^3.0.0
+  checksum: 72183be7bd952425e7fde9c70f1a80394f3b104f27902ff75e6541ab62e2f2c7e1f4e13300474689bb0331836eec943c79aaa803c9e91238112963e09dbec98d
+  languageName: node
+  linkType: hard
+
+"jsprim@npm:^1.2.2":
+  version: 1.4.2
+  resolution: "jsprim@npm:1.4.2"
+  dependencies:
+    assert-plus: 1.0.0
+    extsprintf: 1.3.0
+    json-schema: 0.4.0
+    verror: 1.10.0
+  checksum: 2ad1b9fdcccae8b3d580fa6ced25de930eaa1ad154db21bbf8478a4d30bbbec7925b5f5ff29b933fba9412b16a17bd484a8da4fdb3663b5e27af95dd693bab2a
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.2":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -6309,6 +6675,29 @@ __metadata:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: df82cd1e172f957bae9c536286265a5cdbd5eeca487cb0a3b2a7b41ef959fc61f8e7c0e9aeea9c114ccf2c166b6a8dd45a46fd619c1c569d210ecd2765ad5169
+  languageName: node
+  linkType: hard
+
+"ky-universal@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "ky-universal@npm:0.11.0"
+  dependencies:
+    abort-controller: ^3.0.0
+    node-fetch: ^3.2.10
+  peerDependencies:
+    ky: ">=0.31.4"
+    web-streams-polyfill: ">=3.2.1"
+  peerDependenciesMeta:
+    web-streams-polyfill:
+      optional: true
+  checksum: 42e4c91551a0d17465d6a117de2d1fa4efdf38c4e29dbd70af0c5b7ac0ee13994bceca9af2a0ac21a943d1cd22557ea664abe79f25e096d30a6baca0a0265a12
+  languageName: node
+  linkType: hard
+
+"ky@npm:^0.33.3":
+  version: 0.33.3
+  resolution: "ky@npm:0.33.3"
+  checksum: d1869e1f33c0165355f621b6726fcc1a9de20a31f4a826ca0cfd5753d83b9cba8723402d554a00194e0ee3959e0dda0638f4b99d54a3a7de928b55ff870b0bcc
   languageName: node
   linkType: hard
 
@@ -6598,7 +6987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -6853,7 +7242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^3.3.0":
+"node-fetch@npm:^3.2.10, node-fetch@npm:^3.3.0":
   version: 3.3.1
   resolution: "node-fetch@npm:3.3.1"
   dependencies:
@@ -6861,6 +7250,13 @@ __metadata:
     fetch-blob: ^3.1.4
     formdata-polyfill: ^4.0.10
   checksum: 62145fd3ba4770a76110bc31fdc0054ab2f5442b5ce96e9c4b39fc9e94a3d305560eec76e1165d9259eab866e02a8eecf9301062bb5dfc9f08a4d08b69d223dd
+  languageName: node
+  linkType: hard
+
+"node-forge@npm:^0.10.0, node-forge@npm:~0.10.0":
+  version: 0.10.0
+  resolution: "node-forge@npm:0.10.0"
+  checksum: 5aa6dc9922e424a20ef101d2f517418e2bc9cfc0255dd22e0701c0fad1568445f510ee67f6f3fcdf085812c4ca1b847b8ba45683b34776828e41f5c1794e42e1
   languageName: node
   linkType: hard
 
@@ -6952,6 +7348,13 @@ __metadata:
   version: 2.2.4
   resolution: "nwsapi@npm:2.2.4"
   checksum: a5eb9467158bdf255d27e9c4555e9ca02e4ba84ddce9b683856ed49de23eb1bb28ae3b8e791b7a93d156ad62b324a56f4d44cad827c2ca288c107ed6bdaff8a8
+  languageName: node
+  linkType: hard
+
+"oauth-sign@npm:~0.9.0":
+  version: 0.9.0
+  resolution: "oauth-sign@npm:0.9.0"
+  checksum: 8f5497a127967866a3c67094c21efd295e46013a94e6e828573c62220e9af568cc1d2d04b16865ba583e430510fa168baf821ea78f355146d8ed7e350fc44c64
   languageName: node
   linkType: hard
 
@@ -7195,6 +7598,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"performance-now@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "performance-now@npm:2.1.0"
+  checksum: 534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -7368,7 +7778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.33":
+"psl@npm:^1.1.28, psl@npm:^1.1.33":
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
   checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
@@ -7413,6 +7823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:~6.5.2":
+  version: 6.5.3
+  resolution: "qs@npm:6.5.3"
+  checksum: 6f20bf08cabd90c458e50855559539a28d00b2f2e7dddcb66082b16a43188418cb3cb77cbd09268bcef6022935650f0534357b8af9eeb29bf0f27ccb17655692
+  languageName: node
+  linkType: hard
+
 "querystring@npm:0.2.0":
   version: 0.2.0
   resolution: "querystring@npm:0.2.0"
@@ -7450,6 +7867,25 @@ __metadata:
     randombytes: ^2.0.5
     safe-buffer: ^5.1.0
   checksum: 33734bb578a868d29ee1b8555e21a36711db084065d94e019a6d03caa67debef8d6a1bfd06a2b597e32901ddc761ab483a85393f0d9a75838f1912461d4dbfc7
+  languageName: node
+  linkType: hard
+
+"rdf-canonize@npm:^1.0.2":
+  version: 1.2.0
+  resolution: "rdf-canonize@npm:1.2.0"
+  dependencies:
+    node-forge: ^0.10.0
+    semver: ^6.3.0
+  checksum: 4b704f83ba77f09edfa3c77ad804069ba56ded49e3a91871dfaa0456e0b04e9129fab5a99eb758edf44b25bee0e2c91c27bfc6b91d715e8d96b42296efefbe97
+  languageName: node
+  linkType: hard
+
+"rdf-canonize@npm:^3.0.0":
+  version: 3.3.0
+  resolution: "rdf-canonize@npm:3.3.0"
+  dependencies:
+    setimmediate: ^1.0.5
+  checksum: 4aa4ac59e6ab0bed25cf95fc7f247537507d3f2b2d0742a48dd12a8f2ebc809c0863858f15c73fb8d13f1efe332e4961f7be62fdda9a0abb75d97178410c8cd5
   languageName: node
   linkType: hard
 
@@ -7540,6 +7976,34 @@ __metadata:
   version: 0.8.0
   resolution: "regextras@npm:0.8.0"
   checksum: b7ec5b32a2b98b4b27048d44f8ab90009873c1307f2cf89321aa8c4cbb8147f1bee07863f4dadf585546ca0b91a234ad9804954dea5fc029421f6c25a4523798
+  languageName: node
+  linkType: hard
+
+"request@npm:^2.88.0":
+  version: 2.88.2
+  resolution: "request@npm:2.88.2"
+  dependencies:
+    aws-sign2: ~0.7.0
+    aws4: ^1.8.0
+    caseless: ~0.12.0
+    combined-stream: ~1.0.6
+    extend: ~3.0.2
+    forever-agent: ~0.6.1
+    form-data: ~2.3.2
+    har-validator: ~5.1.3
+    http-signature: ~1.2.0
+    is-typedarray: ~1.0.0
+    isstream: ~0.1.2
+    json-stringify-safe: ~5.0.1
+    mime-types: ~2.1.19
+    oauth-sign: ~0.9.0
+    performance-now: ^2.1.0
+    qs: ~6.5.2
+    safe-buffer: ^5.1.2
+    tough-cookie: ~2.5.0
+    tunnel-agent: ^0.6.0
+    uuid: ^3.3.2
+  checksum: 4e112c087f6eabe7327869da2417e9d28fcd0910419edd2eb17b6acfc4bfa1dad61954525949c228705805882d8a98a86a0ea12d7f739c01ee92af7062996983
   languageName: node
   linkType: hard
 
@@ -7744,7 +8208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
@@ -7771,6 +8235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"security-context@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "security-context@npm:4.0.0"
+  checksum: cae6a5e76701fa384ff79a0f7a84b798e96cb583d0d7308dd2c1ab4128bd75c38f0c0afa465b21696456dc299b8ecb820dae2baeb280cd5f2d65f13d41379fd9
+  languageName: node
+  linkType: hard
+
 "semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.5.1
   resolution: "semver@npm:7.5.1"
@@ -7791,12 +8262,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.0":
+"semver@npm:^6.0.0, semver@npm:^6.2.0, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"serialize-error@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "serialize-error@npm:5.0.0"
+  dependencies:
+    type-fest: ^0.8.0
+  checksum: d298700c4e5350ff812f69fb2024f6e9110b48d8d9e50af1f6c7516446de75bb25ceaa29548ab67165f0c9bf265347c5271f7f1766b0732a0c1582315bf305f0
+  languageName: node
+  linkType: hard
+
+"serialize-error@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "serialize-error@npm:8.1.0"
+  dependencies:
+    type-fest: ^0.20.2
+  checksum: 2eef236d50edd2d7926e602c14fb500dc3a125ee52e9f08f67033181b8e0be5d1122498bdf7c23c80683cddcad083a27974e9e7111ce23165f4d3bcdd6d65102
   languageName: node
   linkType: hard
 
@@ -7813,6 +8302,13 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: c9a6f2c5b51a2dabdc0247db9c46460152ffc62ee139f3157440bd48e7c59425093f42719ac1d7931f054f153e2d26cf37dfeb8da17a794a58198a2705e527fd
   languageName: node
   linkType: hard
 
@@ -7936,6 +8432,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sodium-native@npm:^3.2.0":
+  version: 3.4.1
+  resolution: "sodium-native@npm:3.4.1"
+  dependencies:
+    node-gyp: latest
+    node-gyp-build: ^4.3.0
+  checksum: 88f2f8c9ecb3c7952098b667ee3803f24253d72a3b3874b126e0e36b2ac20432e12ad44bde3664024e6d0ae1bc6d24fdebc81273af161e735f2eec22f10d26dd
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.21, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -8032,6 +8538,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sshpk@npm:^1.7.0":
+  version: 1.17.0
+  resolution: "sshpk@npm:1.17.0"
+  dependencies:
+    asn1: ~0.2.3
+    assert-plus: ^1.0.0
+    bcrypt-pbkdf: ^1.0.0
+    dashdash: ^1.12.0
+    ecc-jsbn: ~0.1.1
+    getpass: ^0.1.1
+    jsbn: ~0.1.0
+    safer-buffer: ^2.0.2
+    tweetnacl: ~0.14.0
+  bin:
+    sshpk-conv: bin/sshpk-conv
+    sshpk-sign: bin/sshpk-sign
+    sshpk-verify: bin/sshpk-verify
+  checksum: ba109f65c8e6c35133b8e6ed5576abeff8aa8d614824b7275ec3ca308f081fef483607c28d97780c1e235818b0f93ed8c8b56d0a5968d5a23fd6af57718c7597
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^9.0.0":
   version: 9.0.1
   resolution: "ssri@npm:9.0.1"
@@ -8101,6 +8628,13 @@ __metadata:
     inherits: ~2.0.4
     readable-stream: ^3.5.0
   checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
+  languageName: node
+  linkType: hard
+
+"streamsearch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "streamsearch@npm:1.1.0"
+  checksum: 1cce16cea8405d7a233d32ca5e00a00169cc0e19fbc02aa839959985f267335d435c07f96e5e0edd0eadc6d39c98d5435fb5bbbdefc62c41834eadc5622ad942
   languageName: node
   linkType: hard
 
@@ -8461,6 +8995,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tough-cookie@npm:~2.5.0":
+  version: 2.5.0
+  resolution: "tough-cookie@npm:2.5.0"
+  dependencies:
+    psl: ^1.1.28
+    punycode: ^2.1.1
+  checksum: 16a8cd090224dd176eee23837cbe7573ca0fa297d7e468ab5e1c02d49a4e9a97bb05fef11320605eac516f91d54c57838a25864e8680e27b069a5231d8264977
+  languageName: node
+  linkType: hard
+
 "tr46@npm:^2.1.0":
   version: 2.1.0
   resolution: "tr46@npm:2.1.0"
@@ -8570,9 +9114,9 @@ __metadata:
   linkType: hard
 
 "tslib@npm:^2.0.0, tslib@npm:^2.1.0":
-  version: 2.5.2
-  resolution: "tslib@npm:2.5.2"
-  checksum: 4d3c1e238b94127ed0e88aa0380db3c2ddae581dc0f4bae5a982345e9f50ee5eda90835b8bfba99b02df10a5734470be197158c36f9129ac49fdc14a6a9da222
+  version: 2.5.0
+  resolution: "tslib@npm:2.5.0"
+  checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
   languageName: node
   linkType: hard
 
@@ -8604,6 +9148,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tunnel-agent@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "tunnel-agent@npm:0.6.0"
+  dependencies:
+    safe-buffer: ^5.0.1
+  checksum: 05f6510358f8afc62a057b8b692f05d70c1782b70db86d6a1e0d5e28a32389e52fa6e7707b6c5ecccacc031462e4bc35af85ecfe4bbc341767917b7cf6965711
+  languageName: node
+  linkType: hard
+
 "tweetnacl@npm:1.x.x, tweetnacl@npm:^1.0.3":
   version: 1.0.3
   resolution: "tweetnacl@npm:1.0.3"
@@ -8611,7 +9164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tweetnacl@npm:^0.14.3":
+"tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
@@ -8654,6 +9207,13 @@ __metadata:
   version: 0.21.3
   resolution: "type-fest@npm:0.21.3"
   checksum: e6b32a3b3877f04339bae01c193b273c62ba7bfc9e325b8703c4ee1b32dc8fe4ef5dfa54bf78265e069f7667d058e360ae0f37be5af9f153b22382cd55a9afe0
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "type-fest@npm:0.8.1"
+  checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7
   languageName: node
   linkType: hard
 
@@ -8757,6 +9317,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^5.21.2":
+  version: 5.22.0
+  resolution: "undici@npm:5.22.0"
+  dependencies:
+    busboy: ^1.6.0
+  checksum: 8dc55240a60ae7680798df344e8f46ad0f872ed0fa434fb94cc4fd2b5b2f8053bdf11994d15902999d3880f9bf7cd875a2e90883d2702bf0f366dacd9cbf3fc6
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^2.0.0":
   version: 2.0.1
   resolution: "unique-filename@npm:2.0.1"
@@ -8855,6 +9424,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^3.3.2":
+  version: 3.4.0
+  resolution: "uuid@npm:3.4.0"
+  bin:
+    uuid: ./bin/uuid
+  checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^9.0.0":
   version: 9.0.0
   resolution: "uuid@npm:9.0.0"
@@ -8886,6 +9464,17 @@ __metadata:
     convert-source-map: ^1.6.0
     source-map: ^0.7.3
   checksum: 54ce92bec2727879626f623d02c8d193f0c7e919941fa373ec135189a8382265117f5316ea317a1e12a5f9c13d84d8449052a731fe3306fa4beaafbfa4cab229
+  languageName: node
+  linkType: hard
+
+"verror@npm:1.10.0":
+  version: 1.10.0
+  resolution: "verror@npm:1.10.0"
+  dependencies:
+    assert-plus: ^1.0.0
+    core-util-is: 1.0.2
+    extsprintf: ^1.2.0
+  checksum: c431df0bedf2088b227a4e051e0ff4ca54df2c114096b0c01e1cbaadb021c30a04d7dd5b41ab277bcd51246ca135bf931d4c4c796ecae7a4fef6d744ecef36ea
   languageName: node
   linkType: hard
 
@@ -9228,6 +9817,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
+  languageName: node
+  linkType: hard
+
+"xmldom@npm:0.1.19":
+  version: 0.1.19
+  resolution: "xmldom@npm:0.1.19"
+  checksum: e7dca2a3e2b33b4c968e8efe3e1609ea6c2b7d73b618ebc23b8dfbde3cad35e03007c72b7887a029d336fb3645a425638db0826d66798cd1a87440c839964285
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
vc-export module provides methods to convert `IDocument` (the verifiable
documents created from '@cord.network/sdk') type of json to `VerifiableCredential`
type of document (ie, the w3c VC standard compliant json). This method also
provides methods to prepare VP (Verifiable Presentation) from the IDocument,
and all methods to verify the proofs attached.

