### PR TITLE
support object in schema

### DIFF
--- a/demo/src/utils/createDocument.ts
+++ b/demo/src/utils/createDocument.ts
@@ -25,6 +25,10 @@ export async function createDocument(
       id: '123456789987654321',
       gender: 'Female',
       country: 'India',
+      address: {
+        street: 'a',
+	pin: 54032
+      }
     },
     holder,
     issuer

--- a/demo/src/utils/generateSchema.ts
+++ b/demo/src/utils/generateSchema.ts
@@ -33,6 +33,9 @@ export async function ensureStoredSchema(
       country: {
         type: 'string',
       },
+      address: {
+        type: 'object',
+      },
     },
     creator
   )

--- a/packages/modules/src/schema/Schema.types.ts
+++ b/packages/modules/src/schema/Schema.types.ts
@@ -25,6 +25,7 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
             { $ref: '#/definitions/boolean' },
             { $ref: '#/definitions/schemaReference' },
             { $ref: '#/definitions/array' },
+            { $ref: '#/definitions/object' },
           ],
           type: 'object',
         },
@@ -122,6 +123,15 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
         },
       },
       required: ['type', 'items'],
+    },
+    object: {
+      additionalProperties: true,
+      properties: {
+        type: {
+          const: 'object',
+        },
+      },
+      required: ['type'],
     },
   },
 }


### PR DESCRIPTION
This is done similar to #23 which was overwritten by DID based work which got in.

This basic feature is required to support any basic schemas in hashmark-studio which uses an image as one of the field.