### PR TITLE
support for nested selective disclosure

### DIFF
--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -273,19 +273,20 @@ async function main() {
 
 
   // Step 5: Create a Presentation
-  console.log(`\n❄️  Presentation Creation `)
+  console.log(`\n❄️  Selective Disclosure Presentation Creation `)
   const challenge = getChallenge()
-  const presentation = await createPresentation(
-    document,
-    async ({ data }) => ({
+  const presentation = await createPresentation({
+    document: document,
+    signCallback: async ({ data }) => ({
       signature: holderKeys.authentication.sign(data),
       keyType: holderKeys.authentication.type,
       keyUri: `${holderDid.uri}${holderDid.authentication[0].id}`,
     }),
-    // [],
-    ['name', 'id', 'address.pin', 'address.location', 'address'],
-    challenge,
-  )
+    // Comment the below line to have a full disclosure
+    selectedAttributes: ['name', 'id', 'address.pin', 'address.location',],
+    challenge: challenge
+  });
+
   console.dir(presentation, {
     depth: null,
     colors: true,
@@ -305,25 +306,28 @@ async function main() {
     console.log('✅  Verification failed! 🚫')
   }
 
-  console.log(`\n❄️  Messaging `)
-  const schemaId = Cord.Schema.idToChain(schema.$id)
-  console.log(' Generating the message - Sender -> Receiver')
-  const message = await generateRequestCredentialMessage(
-    holderDid.uri,
-    verifierDid.uri,
-    schemaId
-  )
+  // Uncomment the following section to enable messaging demo
+  // 
+  // console.log(`\n❄️  Messaging `)
+  // const schemaId = Cord.Schema.idToChain(schema.$id)
+  // console.log(' Generating the message - Sender -> Receiver')
+  // const message = await generateRequestCredentialMessage(
+  //   holderDid.uri,
+  //   verifierDid.uri,
+  //   schemaId
+  // )
+  //
+  // console.log(' Encrypting the message - Sender -> Receiver')
+  // const encryptedMessage = await encryptMessage(
+  //   message,
+  //   holderDid.uri,
+  //   verifierDid.uri,
+  //   holderKeys.keyAgreement
+  // )
+  //
+  // console.log(' Decrypting the message - Receiver')
+  // await decryptMessage(encryptedMessage, verifierKeys.keyAgreement)
 
-  console.log(' Encrypting the message - Sender -> Receiver')
-  const encryptedMessage = await encryptMessage(
-    message,
-    holderDid.uri,
-    verifierDid.uri,
-    holderKeys.keyAgreement
-  )
-
-  console.log(' Decrypting the message - Receiver')
-  await decryptMessage(encryptedMessage, verifierKeys.keyAgreement)
 
   // Step 7: Revoke a Credential
   console.log(`\n❄️  Revoke credential - ${document.identifier}`)

--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -22,10 +22,10 @@ import { generateRequestCredentialMessage } from './utils/request_credential_mes
 import { getChainCredits, addAuthority } from './utils/createAuthorities'
 import { createAccount } from './utils/createAccount'
 
-import type {
-  SignCallback,
-  // DocumenentMetaData,
-} from '@cord.network/types'
+// import type {
+//   SignCallback,
+//   // DocumenentMetaData,
+// } from '@cord.network/types'
 
 function getChallenge(): string {
   return Cord.Utils.UUID.generate()
@@ -94,8 +94,7 @@ async function main() {
     await createDid(authorIdentity)
   const delegateOneKeys = generateKeypairs(delegateOneMnemonic)
   console.log(
-    `🏛   Delegate (${delegateOneDid?.assertionMethod![0].type}): ${
-      delegateOneDid.uri
+    `🏛   Delegate (${delegateOneDid?.assertionMethod![0].type}): ${delegateOneDid.uri
     }`
   )
   // Create Delegate Two DID
@@ -103,8 +102,7 @@ async function main() {
     await createDid(authorIdentity)
   const delegateTwoKeys = generateKeypairs(delegateTwoMnemonic)
   console.log(
-    `🏛   Delegate (${delegateTwoDid?.assertionMethod![0].type}): ${
-      delegateTwoDid.uri
+    `🏛   Delegate (${delegateTwoDid?.assertionMethod![0].type}): ${delegateTwoDid.uri
     }`
   )
   // Create Delegate 3 DID
@@ -112,8 +110,7 @@ async function main() {
     await createDid(authorIdentity)
   const delegate3Keys = generateKeypairs(delegate3Mnemonic)
   console.log(
-    `🏛   Delegate (${delegate3Did?.assertionMethod![0].type}): ${
-      delegate3Did.uri
+    `🏛   Delegate (${delegate3Did?.assertionMethod![0].type}): ${delegate3Did.uri
     }`
   )
   console.log('✅ Identities created!')
@@ -208,13 +205,13 @@ async function main() {
     schema,
     registryDelegate,
     registry.identifier,
-    callBackFn  
+    callBackFn
   )
   console.dir(document, {
     depth: null,
     colors: true,
   })
-  let x = await createStream(
+  await createStream(
     delegateTwoDid.uri,
     authorIdentity,
     async ({ data }) => ({
@@ -225,68 +222,69 @@ async function main() {
   )
   console.log('✅ Credential created!')
 
-  console.log('🖍️ Stream update...')
-  let newContent: any = {
-    name: 'Adi',
-    age: 23,
-    id: '123456789987654311',
-    gender: 'Male',
-    country: 'India',
-  }
+  // console.log('🖍️ Stream update...')
+  // let newContent: any = {
+  //   name: 'Adi',
+  //   age: 23,
+  //   id: '123456789987654311',
+  //   gender: 'Male',
+  //   country: 'India',
+  // }
+  //
+  // const updatedDocument = await Cord.Document.updateStream(
+  //   document,
+  //   newContent,
+  //   schema,
+  //   callBackFn,
+  //   {}
+  // )
+  // console.log('🔖 Document after the updation\n', updatedDocument)
+  //
+  // console.log('⚓ Anchoring the updated document on the blockchain...')
+  // const api = Cord.ConfigService.get('api')
+  // const { streamHash } = Cord.Stream.fromDocument(updatedDocument)
+  // const authorization = Cord.Registry.uriToIdentifier(
+  //   updatedDocument.authorization
+  // )
+  // const streamTx = api.tx.stream.update(
+  //   updatedDocument.identifier.replace('stream:cord:', ''),
+  //   // updatedDocument.identifier,
+  //   streamHash,
+  //   authorization
+  // )
+  //
+  // const authorizedStreamTx = await Cord.Did.authorizeTx(
+  //   delegateTwoDid.uri,
+  //   streamTx,
+  //   async ({ data }) => ({
+  //     signature: delegateTwoKeys.assertionMethod.sign(data),
+  //     keyType: delegateTwoKeys.assertionMethod.type,
+  //   }),
+  //   authorIdentity.address
+  // )
+  // try {
+  //   await Cord.Chain.signAndSubmitTx(authorizedStreamTx, authorIdentity)
+  // }
+  // catch (e) {
+  //   console.log('Error: \n', e.message)
+  // }
+  //
 
-  const updatedDocument = await Cord.Document.updateStream(
-    document,
-    newContent,
-    schema,
-    callBackFn,
-    {}
-  )
-  console.log('🔖 Document after the updation\n', updatedDocument)
 
-  console.log('⚓ Anchoring the updated document on the blockchain...')
-  const api = Cord.ConfigService.get('api')
-  const { streamHash } = Cord.Stream.fromDocument(updatedDocument)
-  const authorization = Cord.Registry.uriToIdentifier(
-    updatedDocument.authorization
-  )
-  const streamTx = api.tx.stream.update(
-    updatedDocument.identifier.replace('stream:cord:', ''),
-    // updatedDocument.identifier,
-    streamHash,
-    authorization
-  )
-
-  const authorizedStreamTx = await Cord.Did.authorizeTx(
-    delegateTwoDid.uri,
-    streamTx,
-    async ({ data }) => ({
-      signature: delegateTwoKeys.assertionMethod.sign(data),
-      keyType: delegateTwoKeys.assertionMethod.type,
-    }),
-    authorIdentity.address
-  )
-  try{
-    await Cord.Chain.signAndSubmitTx(authorizedStreamTx, authorIdentity)
-  }
-  catch(e) {
-    console.log('Error: \n',e.message)
-  }
-  
-
-  
 
   // Step 5: Create a Presentation
   console.log(`\n❄️  Presentation Creation `)
   const challenge = getChallenge()
   const presentation = await createPresentation(
-    updatedDocument,
+    document,
     async ({ data }) => ({
       signature: holderKeys.authentication.sign(data),
       keyType: holderKeys.authentication.type,
       keyUri: `${holderDid.uri}${holderDid.authentication[0].id}`,
     }),
-    ['name', 'id'],
-    challenge
+    // [],
+    ['name', 'id', 'address.pin', 'address.location', 'address'],
+    challenge,
   )
   console.dir(presentation, {
     depth: null,
@@ -302,9 +300,9 @@ async function main() {
   })
 
   if (isValid) {
-    console.log('✅ 301 :Verification successful! 🎉')
+    console.log('✅  Verification successful! 🎉')
   } else {
-    console.log('✅ 301 :Verification failed! 🚫')
+    console.log('✅  Verification failed! 🚫')
   }
 
   console.log(`\n❄️  Messaging `)

--- a/demo/src/utils/createDocument.ts
+++ b/demo/src/utils/createDocument.ts
@@ -27,7 +27,11 @@ export async function createDocument(
       country: 'India',
       address: {
         street: 'a',
-	pin: 54032
+        pin: 54032,
+        location: {
+          state: 'karnataka',
+          country: 'india'
+        }
       }
     },
     holder,

--- a/demo/src/utils/createPresentation.ts
+++ b/demo/src/utils/createPresentation.ts
@@ -9,17 +9,33 @@ import * as Cord from '@cord.network/sdk'
  * @param {string} [challenge] - A challenge string that will be signed by the user's private key.
  * @returns A promise that resolves to a document presentation.
  */
-export async function createPresentation(
-  document: Cord.IDocument,
-  signCallback: Cord.SignCallback,
-  selectedAttributes?: string[],
-  challenge?: string
-): Promise<Cord.IDocumentPresentation> {
+export async function createPresentation({
+  document,
+  signCallback,
+  selectedAttributes = [],
+  challenge,
+}: Cord.PresentationOptions): Promise<Cord.IDocumentPresentation> {
   // Create a presentation with only the specified fields revealed, if specified.
   return Cord.Document.createPresentation({
     document,
     signCallback,
     selectedAttributes,
     challenge,
-  })
+  });
 }
+
+
+// export async function createPresentation(
+//   document,
+//   signCallback: Cord.SignCallback,
+//   selectedAttributes?: string[],
+//   challenge?: string
+// ): Promise<Cord.IDocumentPresentation> {
+//   // Create a presentation with only the specified fields revealed, if specified.
+//   return Cord.Document.createPresentation({
+//     document,
+//     signCallback,
+//     selectedAttributes,
+//     challenge,
+//   })
+// }

--- a/packages/modules/src/content/Content.ts
+++ b/packages/modules/src/content/Content.ts
@@ -47,7 +47,7 @@ function jsonLDcontents(
     return {
       ...result,
       '@context': { '@vocab': vocabulary },
-      ...flattenedContents,
+      ...contents,
     };
   }
 
@@ -152,11 +152,11 @@ export function hashContents(
  */
 export function verifyDisclosedAttributes(
   content: PartialContent,
-  attributes: string[],
   proof: {
     nonces: Record<string, string>
     hashes: string[]
   },
+  attributes?: string[],
   options: Pick<Crypto.HashingOptions, 'hasher'> & {
     canonicalisation?: (content: PartialContent) => string[]
   } = {}
@@ -171,7 +171,6 @@ export function verifyDisclosedAttributes(
   if (attributes && attributes.length) {
     filteredStatements = DataUtils.filterStatements(statements, attributes);
   }
-
   // iterate over statements to produce salted hashes
   const hashed = Crypto.hashStatements(filteredStatements, { ...options, nonces })
   // check resulting hashes

--- a/packages/modules/src/schema/Schema.types.ts
+++ b/packages/modules/src/schema/Schema.types.ts
@@ -27,7 +27,6 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
             { $ref: '#/definitions/array' },
             { $ref: '#/definitions/object' },
           ],
-          type: 'object',
         },
       },
       type: 'object',
@@ -125,79 +124,41 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
       required: ['type', 'items'],
     },
     object: {
-      additionalProperties: true,
+      additionalProperties: false,
       properties: {
-        type: {
-          const: 'object',
+        type: { const: 'object' },
+        properties: {
+          type: 'object',
+          patternProperties: {
+            '^.+$': {
+              oneOf: [
+                { $ref: '#/definitions/string' },
+                { $ref: '#/definitions/number' },
+                { $ref: '#/definitions/boolean' },
+                { $ref: '#/definitions/schemaReference' },
+                { $ref: '#/definitions/array' },
+                { $ref: '#/definitions/object' },
+              ],
+            },
+          },
+        },
+        patternProperties: {
+          '^.+$': {
+            oneOf: [
+              { $ref: '#/definitions/string' },
+              { $ref: '#/definitions/number' },
+              { $ref: '#/definitions/boolean' },
+              { $ref: '#/definitions/schemaReference' },
+              { $ref: '#/definitions/array' },
+              { $ref: '#/definitions/object' },
+            ],
+          },
         },
       },
       required: ['type'],
     },
   },
 }
-
-// export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
-//   $id: 'http://cord.network/draft-01/schema#',
-//   $schema: 'http://json-schema.org/draft-07/schema#',
-//   title: 'CType Metaschema (draft-01)',
-//   description: `Describes a Schema, which is a JSON schema for validating stream types. This version has known issues, the use of schema ${SchemaModelV2.$id} is recommended instead.`,
-//   type: 'object',
-//   properties: {
-//     $id: {
-//       type: 'string',
-//       format: 'uri',
-//       pattern: '^schema:cord:5[0-9a-zA-Z]+$',
-//     },
-//     $schema: {
-//       type: 'string',
-//       format: 'uri',
-//       const: 'http://json-schema.org/draft-07/schema#',
-//     },
-//     title: {
-//       type: 'string',
-//     },
-//     description: {
-//       type: 'string',
-//     },
-//     type: {
-//       type: 'string',
-//       const: 'object',
-//     },
-//     properties: {
-//       type: 'object',
-//       patternProperties: {
-//         '^.*$': {
-//           type: 'object',
-//           properties: {
-//             type: {
-//               type: 'string',
-//               enum: ['string', 'integer', 'number', 'boolean'],
-//             },
-//             $ref: {
-//               type: 'string',
-//               format: 'uri',
-//             },
-//             format: {
-//               type: 'string',
-//               enum: ['date', 'time', 'uri'],
-//             },
-//           },
-//           additionalProperties: false,
-//           oneOf: [
-//             {
-//               required: ['type'],
-//             },
-//             {
-//               required: ['$ref'],
-//             },
-//           ],
-//         },
-//       },
-//     },
-//   },
-//   additionalProperties: false,
-//   required: ['$id', 'title', '$schema', 'properties', 'type'],
-// }
 
 export const SchemaModel: JsonSchema.Schema = {
   $schema: 'http://json-schema.org/draft-07/schema',

--- a/packages/types/src/Document.ts
+++ b/packages/types/src/Document.ts
@@ -23,13 +23,15 @@ export interface IDocument {
   evidenceIds: IDocument[]
   authorization: IRegistryAuthorization['identifier']
   registry: string | null
-  createdAt: string
-  validUntil: string
+  issuanceDate: string
+  validFrom?: string
+  validUntil?: string
   documentHash: Hash
   issuerSignature: DidSignature
   metadata: DocumentMetaData
 }
 
 export interface IDocumentPresentation extends IDocument {
+  selectiveAttributes: string[]
   holderSignature: DidSignature & { challenge?: string }
 }

--- a/packages/types/src/Document.ts
+++ b/packages/types/src/Document.ts
@@ -2,6 +2,7 @@ import type { HexString } from '@polkadot/util/types'
 import type { DidSignature } from './DidDocument'
 import type { IContent } from './Content.js'
 import type { IRegistryAuthorization } from './Registry'
+import type { SignCallback } from './CryptoCallbacks'
 
 export type Hash = HexString
 
@@ -35,3 +36,11 @@ export interface IDocumentPresentation extends IDocument {
   selectiveAttributes: string[]
   holderSignature: DidSignature & { challenge?: string }
 }
+
+export interface PresentationOptions {
+  document: IDocument;
+  signCallback: SignCallback;
+  selectedAttributes?: string[];
+  challenge?: string;
+}
+

--- a/packages/utils/src/Crypto.ts
+++ b/packages/utils/src/Crypto.ts
@@ -159,10 +159,10 @@ export function encodeObjectAsStr(
       ? JSON.stringify(jsonabc.sortObj(value))
       : // eslint-disable-next-line no-nested-ternary
       typeof value === 'number' && value !== null
-      ? value.toString()
-      : typeof value === 'boolean' && value !== null
-      ? JSON.stringify(value)
-      : value
+        ? value.toString()
+        : typeof value === 'boolean' && value !== null
+          ? JSON.stringify(value)
+          : value
 
   return input.normalize('NFC')
 }
@@ -288,6 +288,7 @@ export interface HashingOptions {
   nonces?: Record<string, string>
   nonceGenerator?: (key: string) => string
   hasher?: Hasher
+  // selectedAttributes?: string[]
 }
 
 /**

--- a/packages/vc-export/src/constants.ts
+++ b/packages/vc-export/src/constants.ts
@@ -25,4 +25,4 @@ export const CORD_CREDENTIAL_DIGEST_PROOF_TYPE = 'CordCredentialDigest2020'
 
 export const JSON_SCHEMA_TYPE = 'JsonSchemaValidator2018'
 
-export const CORD_CREDENTIAL_IRI_PREFIX = 'cred:cord:'
+export const CORD_CREDENTIAL_IRI_PREFIX = 'stream:cord:'

--- a/packages/vc-export/src/exportToVerifiableCredential.ts
+++ b/packages/vc-export/src/exportToVerifiableCredential.ts
@@ -67,7 +67,7 @@ export function fromCredential(
 
   const issuer = input.content.issuer
 
-  const issuanceDate = input.createdAt
+  const issuanceDate = input.issuanceDate
   const expirationDate = input.validUntil
   // if schema is given, add as credential schema
   let credentialSchema: CredentialSchema | undefined
@@ -114,7 +114,7 @@ export function fromCredential(
     }
     VC.proof.push(sSProof)
   }
- 
+
   // add credential proof
   const streamProof: CordStreamProof = {
     type: CORD_ANCHORED_PROOF_TYPE,
@@ -127,7 +127,7 @@ export function fromCredential(
   const cDProof: CredentialDigestProof = {
     type: CORD_CREDENTIAL_DIGEST_PROOF_TYPE,
     proofPurpose: 'assertionMethod',
-    nonces: {...input.contentNonceMap},
+    nonces: { ...input.contentNonceMap },
     contentHashes: [...contentHashes],
   }
   VC.proof.push(cDProof)

--- a/packages/vc-export/src/types.ts
+++ b/packages/vc-export/src/types.ts
@@ -71,7 +71,7 @@ export interface VerifiableCredential {
   // when the credential was issued
   issuanceDate: string
   // when the credential will expire
-  expirationDate: string
+  expirationDate?: string
   // streams about the subjects of the credential
   credentialSubject: Record<string, AnyJson>
   // rootHash  of the credential


### PR DESCRIPTION
Support for nested selective disclosure by using a flattened content model.  This PR also has a breaking change on `createPresentation` call. 
**not supported** - selective disclosure of array values

- refactored the function signature to accept an options object. This would allow you to easily omit specific properties and make the function more extensible in the future.

```
interface CreatePresentationOptions {
  document: IDocument;
  signCallback: SignCallback;
  selectedAttributes?: string[];
  challenge?: string;
}
```
Modified  createPresentation function:
```
export async function createPresentation({
  document,
  signCallback,
  selectedAttributes = [],
  challenge,
}: CreatePresentationOptions): Promise<IDocumentPresentation> {
  // ... (rest of the function remains unchanged)
}
```
We can now call the function with just the properties you need. It makes the call more readable and easily extensible.

```
const presentation = await createPresentation({
    document: document,
    signCallback: async ({ data }) => ({
      signature: holderKeys.authentication.sign(data),
      keyType: holderKeys.authentication.type,
      keyUri: `${holderDid.uri}${holderDid.authentication[0].id}`,
    }),
    // selectedAttributes: ['name', 'id', 'address.pin', 'address.location', 'address'],
    challenge: challenge
});
```

In the call above, we can easily omit selectedAttributes. If you want to include selectedAttributes, you can add that property to the options object.

This structure allows for much cleaner function calls, especially when a function has several parameters, and some of them are optional. We should refactor other calls to follow this model.