### PR TITLE
Fix verifyPresentation - Implemented a comparison between the stream hash and the document hash

### DIFF
--- a/demo/src/utils/verifyPresentation.ts
+++ b/demo/src/utils/verifyPresentation.ts
@@ -29,6 +29,9 @@ export async function verifyPresentation(
     if (stream.revoked) {
       return false
     }
+    if (stream.streamHash !== presentation.documentHash) {
+      return false
+    }
     return trustedIssuerUris.includes(stream.issuer)
   } catch {
     return false


### PR DESCRIPTION
The "verifyPresentation" method was initially designed to determine if a stream had been revoked. It would return false only in cases of revocation. However, when dealing with stream updates, the stream remains unrevoked, causing "verifyPresentation" to incorrectly return true for old documents as well. This problem has been resolved by implementing the new check.