### PR TITLE
Ommited the schema check in the verifyRegistryDataStructure method

### DIFF
--- a/packages/modules/src/registry/Registry.ts
+++ b/packages/modules/src/registry/Registry.ts
@@ -42,9 +42,6 @@ import type { PalletRegistryRegistryAuthorization } from '@cord.network/augment-
  *
  */
 export function verifyRegistryDataStructure(input: IRegistry): void {
-  if (!input.meta.schema) {
-    throw new SDKErrors.SchemaMissingError()
-  }
   if (!input.meta.creator) {
     throw new SDKErrors.CreatorMissingError()
   }


### PR DESCRIPTION
Schema is an optional argument  in the `create` method of the registry pallet. Hence, the schema check should be avoided.