### PR TITLE
provide 'required' as an argument while creating schema structure

### DIFF
--- a/demo/src/utils/createDocument.ts
+++ b/demo/src/utils/createDocument.ts
@@ -23,14 +23,12 @@ export async function createDocument(
       name: 'Alice',
       age: 29,
       id: '123456789987654321',
-      gender: 'Female',
       country: 'India',
       address: {
         street: 'a',
         pin: 54032,
         location: {
           state: 'karnataka',
-          country: 'india'
         }
       }
     },

--- a/demo/src/utils/generateSchema.ts
+++ b/demo/src/utils/generateSchema.ts
@@ -37,6 +37,7 @@ export async function ensureStoredSchema(
         type: 'object',
       },
     },
+    [ 'name', 'id', 'age' ],
     creator
   )
 

--- a/packages/modules/src/schema/Schema.ts
+++ b/packages/modules/src/schema/Schema.ts
@@ -211,10 +211,12 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
 export function fromProperties(
   title: ISchema['title'],
   properties: ISchema['properties'],
+  required: ISchema['required'],
   creator: DidUri
 ): ISchema {
   const schema: Omit<ISchema, '$id'> = {
     properties,
+    required,
     title,
     $schema: SchemaModelV1.$id,
     type: 'object',

--- a/packages/modules/src/schema/Schema.types.ts
+++ b/packages/modules/src/schema/Schema.types.ts
@@ -32,6 +32,7 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
       type: 'object',
     },
     additionalProperties: { const: false, type: 'boolean' },
+    required: { type: 'array', items: { type: 'string' } },
   },
   additionalProperties: false,
   required: [

--- a/packages/types/src/Schema.ts
+++ b/packages/types/src/Schema.ts
@@ -54,5 +54,6 @@ export interface ISchema {
       | RefPattern
   }
   type: 'object'
+  required: string[]
   additionalProperties?: false
 }


### PR DESCRIPTION
'required' is very crucial field to be added into the schema to support multiple usecases.

Fixes: #120