### PR TITLE
network dispatch key changes

### DIFF
--- a/demo/src/func-test.ts
+++ b/demo/src/func-test.ts
@@ -151,8 +151,8 @@ async function main() {
     issuerDid.uri,
     authorIdentity,
     async ({ data }) => ({
-      signature: issuerKeys.assertionMethod.sign(data),
-      keyType: issuerKeys.assertionMethod.type,
+      signature: issuerKeys.authentication.sign(data),
+      keyType: issuerKeys.authentication.type,
     })
   )
   console.dir(space, {
@@ -237,8 +237,8 @@ async function main() {
     authorIdentity,
     space.authorization,
     async ({ data }) => ({
-      signature: issuerKeys.assertionMethod.sign(data),
-      keyType: issuerKeys.assertionMethod.type,
+      signature: issuerKeys.authentication.sign(data),
+      keyType: issuerKeys.authentication.type,
     })
   )
   console.log(`✅ Schema - ${schemaId} - added!`)
@@ -282,8 +282,8 @@ async function main() {
     authorIdentity,
     space.authorization,
     async ({ data }) => ({
-      signature: issuerKeys.assertionMethod.sign(data),
-      keyType: issuerKeys.assertionMethod.type,
+      signature: issuerKeys.authentication.sign(data),
+      keyType: issuerKeys.authentication.type,
     })
   )
 
@@ -314,8 +314,8 @@ async function main() {
     authorIdentity,
     delegateAuth as Cord.AuthorizationUri,
     async ({ data }) => ({
-      signature: delegateTwoKeys.assertionMethod.sign(data),
-      keyType: delegateTwoKeys.assertionMethod.type,
+      signature: delegateTwoKeys.authentication.sign(data),
+      keyType: delegateTwoKeys.authentication.type,
     })
   )
   console.log(`✅ Statement element registered - ${updatedStatement}`)
@@ -357,8 +357,8 @@ async function main() {
     authorIdentity,
     delegateAuth,
     async ({ data }) => ({
-      signature: delegateTwoKeys.assertionMethod.sign(data),
-      keyType: delegateTwoKeys.assertionMethod.type,
+      signature: delegateTwoKeys.authentication.sign(data),
+      keyType: delegateTwoKeys.authentication.type,
     })
   )
   console.log(`✅ Statement revoked!`)
@@ -388,8 +388,8 @@ async function main() {
     authorIdentity,
     delegateAuth,
     async ({ data }) => ({
-      signature: delegateTwoKeys.assertionMethod.sign(data),
-      keyType: delegateTwoKeys.assertionMethod.type,
+      signature: delegateTwoKeys.authentication.sign(data),
+      keyType: delegateTwoKeys.authentication.type,
     })
   )
   console.log(`✅ Statement revoked!`)

--- a/demo/src/func-test.ts
+++ b/demo/src/func-test.ts
@@ -231,7 +231,7 @@ async function main() {
     depth: null,
     colors: true,
   })
-  const schemaId = await Cord.Schema.dispatchToChain(
+  const schemaUri = await Cord.Schema.dispatchToChain(
     schemaProperties.schema,
     issuerDid.uri,
     authorIdentity,
@@ -241,7 +241,7 @@ async function main() {
       keyType: issuerKeys.authentication.type,
     })
   )
-  console.log(`✅ Schema - ${schemaId} - added!`)
+  console.log(`✅ Schema - ${schemaUri} - added!`)
 
   console.log(`\n❄️  Query From Chain - Schema `)
   const schemaFromChain = await Cord.Schema.fetchFromChain(
@@ -269,7 +269,8 @@ async function main() {
   const statementEntry = Cord.Statement.buildFromProperties(
     credHash,
     space.uri,
-    issuerDid.uri
+    issuerDid.uri,
+    schemaUri
   )
   console.dir(statementEntry, {
     depth: null,
@@ -325,7 +326,8 @@ async function main() {
     statementEntry.elementUri,
     credHash,
     issuerDid.uri,
-    space.uri
+    space.uri,
+    schemaUri
   )
 
   if (verificationResult.isValid) {
@@ -344,10 +346,12 @@ async function main() {
 
   if (anotherVerificationResult.isValid) {
     console.log(
-      `✅ Verification successful! "${updatedStatementEntry.elementUri}" 🎉`
+      `\n✅ Verification successful! "${updatedStatementEntry.elementUri}" 🎉`
     )
   } else {
-    console.log(`🚫 Verification failed! - "${verificationResult.message}" 🚫`)
+    console.log(
+      `\n🚫 Verification failed! - "${verificationResult.message}" 🚫`
+    )
   }
 
   console.log(`\n❄️  Revoke Statement - ${updatedStatementEntry.elementUri}`)

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -20,22 +20,21 @@ import {
 } from '../Did.chain.js'
 
 const methodMapping: Record<string, VerificationKeyRelationship | undefined> = {
-  statement: 'assertionMethod',
-  schema: 'assertionMethod',
+  statement: 'authentication',
+  schema: 'authentication',
   'chainSpace.addAdminDelegate': 'capabilityDelegation',
   'chainSpace.addAuditDelegate': 'capabilityDelegation',
   'chainSpace.addDelegate': 'capabilityDelegation',
   'chainSpace.removeDelegate': 'capabilityDelegation',
-  'chainSpace.create': 'assertionMethod',
-  'chainSpace.archive': 'assertionMethod',
-  'chainSpace.restore': 'assertionMethod',
-  unique: 'assertionMethod',
+  'chainSpace.create': 'authentication',
+  'chainSpace.archive': 'authentication',
+  'chainSpace.restore': 'authentication',
   did: 'authentication',
   'did.create': undefined,
   'did.submitDidCall': undefined,
   didLookup: 'authentication',
   didName: 'authentication',
-  score: 'assertionMethod',
+  score: 'authentication',
 }
 
 function getKeyRelationshipForMethod(

--- a/packages/statement/src/Statement.chain.ts
+++ b/packages/statement/src/Statement.chain.ts
@@ -590,7 +590,6 @@ export async function fetchStatementDetailsfromChain(
     )
   }
 
-  console.log(statementDetails)
   const schemaUri =
     statementDetails.schemaUri !== undefined
       ? identifierToUri(statementDetails.schemaUri)

--- a/packages/statement/src/Statement.ts
+++ b/packages/statement/src/Statement.ts
@@ -34,6 +34,7 @@ import type {
   SpaceUri,
   DidUri,
   StatementUri,
+  PartialStatementEntry,
 } from '@cord.network/types'
 import { DataUtils, SDKErrors } from '@cord.network/utils'
 import { checkIdentifier, updateStatementUri } from '@cord.network/identifier'
@@ -178,17 +179,15 @@ export function buildFromUpdateProperties(
   stmtUri: StatementUri,
   digest: HexString,
   spaceUri: SpaceUri,
-  creatorUri: DidUri,
-  schemaUri?: SchemaUri
-): IStatementEntry {
+  creatorUri: DidUri
+): PartialStatementEntry {
   const statementUri = updateStatementUri(stmtUri, digest)
-
+  // TODO fetch on-chain data and compare the update inputs
   const statement = {
     elementUri: statementUri,
     digest,
     creatorUri,
     spaceUri,
-    schemaUri: schemaUri || undefined,
   }
   verifyDataStructure(statement)
   return statement
@@ -251,7 +250,6 @@ export async function verifyAgainstProperties(
   schemaUri?: SchemaUri
 ): Promise<{ isValid: boolean; message: string }> {
   try {
-    console.log(stmtUri)
     const statementStatus = await fetchStatementDetailsfromChain(stmtUri)
 
     if (!statementStatus) {

--- a/packages/types/src/Statement.ts
+++ b/packages/types/src/Statement.ts
@@ -21,6 +21,8 @@ export interface IStatementEntry {
   schemaUri?: SchemaUri | undefined
 }
 
+export type PartialStatementEntry = Omit<IStatementEntry, 'schemaUri'>
+
 export interface IStatementDetails {
   uri: StatementUri
   digest: StatementDigest


### PR DESCRIPTION
All network interactions except delegations will use the DID authentication key to sign the extrinsic. The off-chain document signing will continue to use the DID assertion method. 