### PR TITLE
Include confidex

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -90,5 +90,25 @@ export const typesBundle: OverrideBundleType = {
       },
       types: defaultTypesBundle,
     },
+    'Confidex-Alpha': {
+      runtime: {
+        ...didApiCalls,
+        ...TransactionWeightApiCalls,
+      },
+      signedExtensions: {
+        ...cordSignedExtensions,
+      },
+      types: defaultTypesBundle,
+    },
+    'NPCI-Alpha': {
+      runtime: {
+        ...didApiCalls,
+        ...TransactionWeightApiCalls,
+      },
+      signedExtensions: {
+        ...cordSignedExtensions,
+      },
+      types: defaultTypesBundle,
+    },
   },
 }


### PR DESCRIPTION
The typeBundle needs to work with `name` field of the chain spec for now, and hence we need this reference for now for every new network.