### PR TITLE
network-score: change methods to suit the need of API spec

### DIFF
--- a/packages/network-score/src/Scoring.chain.ts
+++ b/packages/network-score/src/Scoring.chain.ts
@@ -55,7 +55,6 @@ import { uriToIdentifier, identifierToUri } from '@cord.network/identifier'
 import { Chain } from '@cord.network/network'
 import { ConfigService } from '@cord.network/config'
 import { SDKErrors, DecoderUtils, DataUtils } from '@cord.network/utils'
-import { verifySignature } from './Scoring.js'
 
 /**
  * Checks if a specific rating is stored in the blockchain.
@@ -225,11 +224,6 @@ export async function dispatchRevokeRatingToChain(
 ): Promise<RatingEntryUri> {
   try {
     const api = ConfigService.get('api')
-    verifySignature(
-      ratingEntry.entryDigest,
-      ratingEntry.authorSignature,
-      Did.getDidUri(ratingEntry.authorUri)
-    )
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 


### PR DESCRIPTION
with more discussions, it was aggreed that it is entity writing to chain's task to build the payload.

In some cases, as in the example script, the validation of source is done by the application itself (example, the API for ONDC score may be done by Beckn signature check methods).