### PR TITLE
Fix: package/statement: Throw error and return identifier when attempting to anchor an already existing statement

### DIFF
--- a/packages/statement/src/Statement.chain.ts
+++ b/packages/statement/src/Statement.chain.ts
@@ -219,7 +219,9 @@ export async function dispatchRegisterToChain(
 
     const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri)
     if (exists) {
-      return stmtEntry.elementUri
+      throw new SDKErrors.DuplicateStatementError(
+        `The statement is already anchored in the chain\nIdentifier: ${stmtEntry.elementUri}`
+      )
     }
 
     const tx = schemaId

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -246,3 +246,5 @@ export class AssetInstanceNotFound extends SDKError {}
 export class AssetNotFound extends SDKError {}
 
 export class AssetStatusError extends SDKError {}
+
+export class DuplicateStatementError extends SDKError {}


### PR DESCRIPTION
This a fix to the issue: https://github.com/dhiway/cord.js/issues/177