### PR TITLE
Add checks for enums before dispatch

### DIFF
--- a/packages/asset/src/Asset.chain.ts
+++ b/packages/asset/src/Asset.chain.ts
@@ -296,6 +296,11 @@ export async function dispatchAssetStatusChangeToChain(
     const api = ConfigService.get('api')
     let tx
 
+    /* Check if assetStatusType is undefined */
+    if (newStatus === undefined) {
+      throw new SDKErrors.InvalidAssetStatus("Asset status is undefined.");
+    }
+
     if (assetInstanceId) {
       let encodedAssetInstanceDetail = await api.query.asset.issuance(
         assetId,
@@ -361,6 +366,11 @@ export async function dispatchAssetStatusChangeVcToChain(
   try {
     const api = ConfigService.get('api')
     let tx
+    
+    /* Check if assetStatusType is undefined */
+    if (newStatus === undefined) {
+      throw new SDKErrors.InvalidAssetStatus("Asset status is undefined.");
+    }
 
     if (assetInstanceId) {
       let encodedAssetInstanceDetail = await api.query.asset.vcIssuance(

--- a/packages/asset/src/Asset.ts
+++ b/packages/asset/src/Asset.ts
@@ -34,6 +34,8 @@ import { Crypto } from '@cord.network/utils'
 import { ConfigService } from '@cord.network/config'
 import * as Did from '@cord.network/did'
 
+import { SDKErrors } from '@cord.network/utils'
+
 export async function buildFromAssetProperties(
     assetInput: IAssetProperties,
     issuer: DidUri,
@@ -70,6 +72,11 @@ export async function buildFromAssetProperties(
     digest: entryDigest,
     uri: assetIdentifier,
   };
+
+  /* Check if assetType is undefined */
+  if (assetInput.assetType === undefined) {
+    throw new SDKErrors.InvalidAssetType("Asset type is undefined.");
+  }
 
   return transformedEntry;
 }

--- a/packages/network-score/src/Scoring.ts
+++ b/packages/network-score/src/Scoring.ts
@@ -358,6 +358,7 @@ export async function buildFromRatingProperties(
       rating.entryDigest,
       rating.entry.entityId,
       rating.entry.providerDid,
+      rating.entry.ratingType,
     ])
     validateHexString(rating.entryDigest)
 
@@ -500,6 +501,7 @@ export async function buildFromReviseRatingProperties(
       rating.referenceId,
       rating.entry.countOfTxn,
       rating.entry.totalEncodedRating,
+      rating.entry.ratingType,
     ])
 
     validateHexString(rating.entryDigest)

--- a/packages/utils/src/SDKErrors.ts
+++ b/packages/utils/src/SDKErrors.ts
@@ -77,6 +77,7 @@ export class InvalidInputError extends SDKError {}
 // Score Errors
 export class RatingContentError extends SDKError {}
 export class RatingPropertiesError extends SDKError {}
+export class InvalidRatingType extends SDKError {}
 
 // export class ScoreCollectorMissingError extends SDKError {}
 // export class ScoreEntityMissingError extends SDKError {}
@@ -246,5 +247,9 @@ export class AssetInstanceNotFound extends SDKError {}
 export class AssetNotFound extends SDKError {}
 
 export class AssetStatusError extends SDKError {}
+
+export class InvalidAssetType extends SDKError {}
+
+export class InvalidAssetStatus extends SDKError {}
 
 export class DuplicateStatementError extends SDKError {}


### PR DESCRIPTION
Extra check in SDK level when enum is of invalid which reaches to the chain as `undefined` which leads to 0th enum being set. Add a extra check to avoid this.