### PR TITLE
Feature to support multi chains for CORD.js SDK

### DIFF
--- a/demo/src/asset-tx.ts
+++ b/demo/src/asset-tx.ts
@@ -19,22 +19,12 @@ async function main() {
   const networkAddress = NETWORK_ADDRESS ?? 'ws://127.0.0.1:9944';
   const anchorUri = ANCHOR_URI ?? '//Alice';
 
-  // Temporarily suppress console.log
-  // let originalConsoleLog = console.log;
-  // console.log = () => {};
   Cord.ConfigService.set({ submitTxResolveOn: Cord.Chain.IS_IN_BLOCK });
   
-  let connName = "random";
-  await Cord.connect(networkAddress, connName);
-  const api = Cord.ConfigService.get(connName);
+  let network = "api-1";
+  await Cord.connect(networkAddress, network);
+  const api = Cord.ConfigService.get(network);
 
-  // let connName = 'api';
-  // await Cord.connect(networkAddress);
-  // const api = Cord.ConfigService.get('api')
-
-  //console.log("api in tx file", api);
-  // Restore console.log
-  //console.log = originalConsoleLog;
   console.log(`\nOn-Chain Assets & Transactions  `);
 
   // Step 1: Setup Identities
@@ -47,7 +37,7 @@ async function main() {
   //  const { account: issuerIdentity } = createAccount();
     // Create issuer DID
   const { mnemonic: issuerMnemonic, document: issuerDid } = await createDid(
-    networkAuthorityIdentity, connName
+    networkAuthorityIdentity, network
   )
   const issuerKeys = Cord.Utils.Keys.generateKeypairs(issuerMnemonic, 'sr25519')
   console.log(
@@ -55,14 +45,14 @@ async function main() {
   )
 
   const { mnemonic: holderMnemonic, document: holderDid } = await createDid(
-    networkAuthorityIdentity, connName
+    networkAuthorityIdentity, network
   )
   const holderKeys = Cord.Utils.Keys.generateKeypairs(holderMnemonic, 'sr25519')
   console.log(
     `🏛   Holder (${holderDid?.assertionMethod![0].type}): ${holderDid.uri}`
   )
   const { mnemonic: holder2Mnemonic, document: holder2Did } = await createDid(
-    networkAuthorityIdentity, connName
+    networkAuthorityIdentity, network
   )
   console.log(
     `🏛   Holder2 (${holder2Did?.assertionMethod![0].type}): ${holder2Did.uri}`
@@ -72,13 +62,13 @@ async function main() {
   console.log(`🏦  API Provider (${apiIdentity.type}): ${apiIdentity.address}`);
 
   //  await addNetworkMember(networkAuthorityIdentity, issuerIdentity.address);
-  await addNetworkMember(networkAuthorityIdentity, apiIdentity.address, connName);
+  await addNetworkMember(networkAuthorityIdentity, apiIdentity.address, network);
   console.log("✅ Identities created!");
 
   // Step 3: Create a new Chain Space
   console.log(`\n❄️  Chain Space Creation `)
   const spaceProperties = await Cord.ChainSpace.buildFromProperties(
-    issuerDid.uri, {connName}
+    issuerDid.uri, {network}
   )
   console.dir(spaceProperties, {
     depth: null,
@@ -94,7 +84,7 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.dir(space, {
     depth: null,
@@ -107,7 +97,7 @@ async function main() {
     networkAuthorityIdentity,
     space.uri,
     100,
-    connName
+    network
   )
   console.log(`✅  Chain Space Approved`)
 
@@ -131,7 +121,7 @@ async function main() {
     assetProperties,
     issuerDid.uri,
     space.uri,
-    connName
+    network
   );
 
   console.log(`\n❄️  Asset Transaction  - Created by Issuer  `);
@@ -148,7 +138,7 @@ async function main() {
         signature: issuerKeys.authentication.sign(data),
         keyType: issuerKeys.authentication.type,
       }),
-      connName
+      network
     )
 
   console.log("✅ Asset created!");
@@ -161,7 +151,7 @@ async function main() {
     1,
     issuerDid.uri,
     space.uri,
-    connName
+    network
   );
 
   console.dir(assetIssuance, {
@@ -177,7 +167,7 @@ async function main() {
         signature: issuerKeys.authentication.sign(data),
         keyType: issuerKeys.authentication.type,
       }),
-      connName
+      network
     )
 
   // Step 4: Transfer Asset to New Owner
@@ -201,7 +191,7 @@ async function main() {
         signature: holderKeys.authentication.sign(data),
         keyType: holderKeys.authentication.type,
       }),
-      connName
+      network
     )
 
   console.log("✅ Asset transferred!");
@@ -218,7 +208,7 @@ async function main() {
         signature: issuerKeys.authentication.sign(data),
         keyType: issuerKeys.authentication.type,
       }),
-      { assetInstanceId: assetIssuance.uri, connName }
+      { assetInstanceId: assetIssuance.uri, network }
     )
 
   console.log("✅ Asset status changed!");
@@ -226,13 +216,13 @@ async function main() {
 main()
   .then(() => console.log("\nBye! 👋 👋 👋 "))
   .finally(async () => {
-      let connName = "random";
-      await Cord.disconnect(connName);
+      let network = "api-1";
+      await Cord.disconnect(network);
     });
 
 process.on("SIGINT", async () => {
   console.log("\nBye! 👋 👋 👋 \n");
-  let connName = "random";
-  await Cord.disconnect(connName);
+  let network = "api-1";
+  await Cord.disconnect(network);
   process.exit(0);
 });

--- a/demo/src/demo-score.ts
+++ b/demo/src/demo-score.ts
@@ -12,7 +12,9 @@ async function main() {
   Cord.ConfigService.set({ submitTxResolveOn: Cord.Chain.IS_IN_BLOCK })
   await Cord.connect(networkAddress)
 
-  const api = Cord.ConfigService.get('api')
+  let connName = "random";
+  await Cord.connect(networkAddress, connName);
+  const api = Cord.ConfigService.get(connName);
 
   console.log(`\n❄️   New Member\n`)
   const authorityAuthorIdentity = Crypto.makeKeypairFromUri(
@@ -29,7 +31,8 @@ async function main() {
   // Step 2: Setup Identities
   console.log(`\n❄️   Demo Identities (KeyRing)\n`)
   const { mnemonic: issuerMnemonic, document: issuerDid } = await createDid(
-    authorIdentity
+    authorIdentity,
+    connName
   )
   const issuerKeys = Cord.Utils.Keys.generateKeypairs(issuerMnemonic)
   console.log(
@@ -38,7 +41,7 @@ async function main() {
 
   // Create Delegate One DID
   const { mnemonic: delegateOneMnemonic, document: delegateOneDid } =
-    await createDid(authorIdentity)
+    await createDid(authorIdentity, connName)
 
   const delegateOneKeys = Cord.Utils.Keys.generateKeypairs(delegateOneMnemonic)
 
@@ -111,11 +114,17 @@ async function main() {
         signature: issuerKeys.assertionMethod.sign(data),
         keyType: issuerKeys.assertionMethod.type,
       }),
-      authorIdentity.address
+      authorIdentity.address,
+      {},
+      connName
     )
     console.log('\n', txRegistry)
     // Write to chain then return the Schema.
-    await Cord.Chain.signAndSubmitTx(extrinsic, authorIdentity)
+    await Cord.Chain.signAndSubmitTx(
+      extrinsic,
+      authorIdentity,
+      { connName }
+    )
     registry = txRegistry
   }
   console.log('\n✅ Registry created!')

--- a/demo/src/demo-score.ts
+++ b/demo/src/demo-score.ts
@@ -12,9 +12,9 @@ async function main() {
   Cord.ConfigService.set({ submitTxResolveOn: Cord.Chain.IS_IN_BLOCK })
   await Cord.connect(networkAddress)
 
-  let connName = "random";
-  await Cord.connect(networkAddress, connName);
-  const api = Cord.ConfigService.get(connName);
+  let network = "random";
+  await Cord.connect(networkAddress, network);
+  const api = Cord.ConfigService.get(network);
 
   console.log(`\n❄️   New Member\n`)
   const authorityAuthorIdentity = Crypto.makeKeypairFromUri(
@@ -32,7 +32,7 @@ async function main() {
   console.log(`\n❄️   Demo Identities (KeyRing)\n`)
   const { mnemonic: issuerMnemonic, document: issuerDid } = await createDid(
     authorIdentity,
-    connName
+    network
   )
   const issuerKeys = Cord.Utils.Keys.generateKeypairs(issuerMnemonic)
   console.log(
@@ -41,7 +41,7 @@ async function main() {
 
   // Create Delegate One DID
   const { mnemonic: delegateOneMnemonic, document: delegateOneDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
 
   const delegateOneKeys = Cord.Utils.Keys.generateKeypairs(delegateOneMnemonic)
 
@@ -116,14 +116,14 @@ async function main() {
       }),
       authorIdentity.address,
       {},
-      connName
+      network
     )
     console.log('\n', txRegistry)
     // Write to chain then return the Schema.
     await Cord.Chain.signAndSubmitTx(
       extrinsic,
       authorIdentity,
-      { connName }
+      { network }
     )
     registry = txRegistry
   }

--- a/demo/src/func-test.ts
+++ b/demo/src/func-test.ts
@@ -24,9 +24,10 @@ async function main() {
     : 'ws://127.0.0.1:9944'
   //  const networkAddress = 'ws://127.0.0.1:9944'
   Cord.ConfigService.set({ submitTxResolveOn: Cord.Chain.IS_IN_BLOCK })
-  let connName = "random";
-  await Cord.connect(networkAddress, connName);
-  const api = Cord.ConfigService.get(connName);
+  
+  let network = "api-1";
+  await Cord.connect(networkAddress, network);
+  const api = Cord.ConfigService.get(network);
 
   // Step 1: Setup Membership
   // Setup transaction author account - CORD Account.
@@ -41,20 +42,20 @@ async function main() {
   console.log(
     `🏦  Member (${authorityIdentity.type}): ${authorityIdentity.address}`
   )
-  await addNetworkMember(authorityAuthorIdentity, authorityIdentity.address, connName)
-  await setRegistrar(authorityAuthorIdentity, authorityIdentity.address, connName)
+  await addNetworkMember(authorityAuthorIdentity, authorityIdentity.address, network)
+  await setRegistrar(authorityAuthorIdentity, authorityIdentity.address, network)
   console.log('✅ Network Authority created!')
 
   // Setup network member account.
   const { account: authorIdentity } = await createAccount()
   console.log(`🏦  Member (${authorIdentity.type}): ${authorIdentity.address}`)
-  await addNetworkMember(authorityAuthorIdentity, authorIdentity.address, connName)
+  await addNetworkMember(authorityAuthorIdentity, authorIdentity.address, network)
   console.log(`🔏  Member permissions updated`)
-  await setIdentity(authorIdentity, connName)
+  await setIdentity(authorIdentity, network)
   console.log(`🔏  Member identity info updated`)
-  await requestJudgement(authorIdentity, authorityIdentity.address, connName)
+  await requestJudgement(authorIdentity, authorityIdentity.address, network)
   console.log(`🔏  Member identity judgement requested`)
-  await provideJudgement(authorityIdentity, authorIdentity.address, connName)
+  await provideJudgement(authorityIdentity, authorIdentity.address, network)
   console.log(`🔏  Member identity judgement provided`)
   console.log('✅ Network Member added!')
 
@@ -64,7 +65,7 @@ async function main() {
   /* Creating the DIDs for the different parties involved in the demo. */
   // Create Verifier DID
   const { mnemonic: verifierMnemonic, document: verifierDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const verifierKeys = Cord.Utils.Keys.generateKeypairs(
     verifierMnemonic,
     'sr25519'
@@ -74,14 +75,14 @@ async function main() {
   )
   // Create Holder DID
   const { mnemonic: holderMnemonic, document: holderDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const holderKeys = Cord.Utils.Keys.generateKeypairs(holderMnemonic, 'sr25519')
   console.log(
     `👩‍⚕️  Holder (${holderDid.assertionMethod![0].type}): ${holderDid.uri}`
   )
   // Create issuer DID
   const { mnemonic: issuerMnemonic, document: issuerDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const issuerKeys = Cord.Utils.Keys.generateKeypairs(issuerMnemonic, 'sr25519')
   console.log(
     `🏛   Issuer (${issuerDid?.assertionMethod![0].type}): ${issuerDid.uri}`
@@ -96,7 +97,7 @@ async function main() {
   })
   // Create Delegate One DID
   const { mnemonic: delegateOneMnemonic, document: delegateOneDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const delegateOneKeys = Cord.Utils.Keys.generateKeypairs(
     delegateOneMnemonic,
     'sr25519'
@@ -108,7 +109,7 @@ async function main() {
   )
   // Create Delegate Two DID
   const { mnemonic: delegateTwoMnemonic, document: delegateTwoDid } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const delegateTwoKeys = Cord.Utils.Keys.generateKeypairs(
     delegateTwoMnemonic,
     'sr25519'
@@ -120,7 +121,7 @@ async function main() {
   )
   // Create Delegate 3 DID
   const { mnemonic: delegate3Mnemonic, document: delegate3Did } =
-    await createDid(authorIdentity, connName)
+    await createDid(authorIdentity, network)
   const delegate3Keys = Cord.Utils.Keys.generateKeypairs(
     delegate3Mnemonic,
     'sr25519'
@@ -144,15 +145,15 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`✅ DID name - ${randomDidName} - created!`)
-  await getDidDocFromName(randomDidName, connName)
+  await getDidDocFromName(randomDidName, network)
 
   // Step 3: Create a new Chain Space
   console.log(`\n❄️  Chain Space Creation `)
   const spaceProperties = await Cord.ChainSpace.buildFromProperties(
-    issuerDid.uri, {connName}
+    issuerDid.uri, {network}
   )
   console.dir(spaceProperties, {
     depth: null,
@@ -168,7 +169,7 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.dir(space, {
     depth: null,
@@ -181,13 +182,13 @@ async function main() {
     authorityAuthorIdentity,
     space.uri,
     1000,
-    connName
+    network
   )
   console.log(`✅  Chain Space Approved`)
 
   // Step 3.5: Subspace
   const subSpaceProperties = await Cord.ChainSpace.buildFromProperties(
-    issuerDid.uri, {connName}
+    issuerDid.uri, {network}
   )
   console.dir(subSpaceProperties, {
     depth: null,
@@ -203,7 +204,7 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.dir(subSpace, {
     depth: null,
@@ -220,7 +221,7 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`\n❄️  SubSpace limit is updated`)
 
@@ -233,7 +234,7 @@ async function main() {
       delegateTwoDid.uri,
       permission,
       issuerDid.uri,
-      connName
+      network
     )
   console.dir(spaceAuthProperties, {
     depth: null,
@@ -248,7 +249,7 @@ async function main() {
       signature: issuerKeys.capabilityDelegation.sign(data),
       keyType: issuerKeys.capabilityDelegation.type,
     }),
-    connName
+    network
   )
   console.dir(delegateAuth, {
     depth: null,
@@ -257,7 +258,7 @@ async function main() {
   console.log(`✅ Space Authorization - ${delegateAuth} - added!`)
 
   console.log(`\n❄️  Query From Chain - Chain Space Details `)
-  const spaceFromChain = await Cord.ChainSpace.fetchFromChain(space.uri, connName)
+  const spaceFromChain = await Cord.ChainSpace.fetchFromChain(space.uri, network)
   console.dir(spaceFromChain, {
     depth: null,
     colors: true,
@@ -266,7 +267,7 @@ async function main() {
   console.log(`\n❄️  Query From Chain - Chain Space Authorization Details `)
   const spaceAuthFromChain = await Cord.ChainSpace.fetchAuthorizationFromChain(
     delegateAuth as Cord.AuthorizationUri,
-    connName
+    network
   )
   console.dir(spaceAuthFromChain, {
     depth: null,
@@ -284,7 +285,7 @@ async function main() {
     newSchemaContent,
     space.uri,
     issuerDid.uri,
-    connName
+    network
   )
   console.dir(schemaProperties, {
     depth: null,
@@ -299,13 +300,13 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`✅ Schema - ${schemaUri} - added!`)
 
   console.log(`\n❄️  Query From Chain - Schema `)
   const schemaFromChain = await Cord.Schema.fetchFromChain(
-    schemaProperties.schema.$id, connName
+    schemaProperties.schema.$id, network
   )
   console.dir(schemaFromChain, {
     depth: null,
@@ -331,7 +332,7 @@ async function main() {
     space.uri,
     issuerDid.uri,
     schemaUri as Cord.SchemaUri,
-    connName
+    network
   )
   console.dir(statementEntry, {
     depth: null,
@@ -347,7 +348,7 @@ async function main() {
       signature: issuerKeys.authentication.sign(data),
       keyType: issuerKeys.authentication.type,
     }),
-    connName
+    network
   )
 
   console.log(`✅ Statement element registered - ${statement}`)
@@ -380,7 +381,7 @@ async function main() {
       signature: delegateTwoKeys.authentication.sign(data),
       keyType: delegateTwoKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`✅ Statement element registered - ${updatedStatement}`)
 
@@ -392,7 +393,7 @@ async function main() {
       creator: issuerDid.uri,
       spaceuri: space.uri,
       schemaUri: schemaUri as Cord.SchemaUri,
-      connName
+      network
     }
   )
 
@@ -409,7 +410,7 @@ async function main() {
       {
         creator: delegateTwoDid.uri,
         spaceuri: space.uri,
-        connName
+        network
       }
     )
 
@@ -433,7 +434,7 @@ async function main() {
       signature: delegateTwoKeys.authentication.sign(data),
       keyType: delegateTwoKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`✅ Statement revoked!`)
 
@@ -444,7 +445,7 @@ async function main() {
     { 
       creator: issuerDid.uri,
       spaceuri: space.uri,
-      connName
+      network
     }
   )
 
@@ -468,7 +469,7 @@ async function main() {
       signature: delegateTwoKeys.authentication.sign(data),
       keyType: delegateTwoKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log(`✅ Statement revoked!`)
 
@@ -479,7 +480,7 @@ async function main() {
     {
       creator: delegateTwoDid.uri,
       spaceuri: space.uri,
-      connName
+      network
     }
   )
 
@@ -496,13 +497,13 @@ async function main() {
 main()
   .then(() => console.log('\nBye! 👋 👋 👋 '))
   .finally(async () => {
-      let connName = "random";
-      await Cord.disconnect(connName);
+      let network = "api-1";
+      await Cord.disconnect(network);
     });
 
 process.on('SIGINT', async () => {
   console.log('\nBye! 👋 👋 👋 \n')
-  let connName = "random";
-  await Cord.disconnect(connName);
+  let network = "api-1";
+  await Cord.disconnect(network);
   process.exit(0)
 })

--- a/demo/src/network-score-test.ts
+++ b/demo/src/network-score-test.ts
@@ -8,11 +8,10 @@ import { createAccount } from './utils/createAccount'
 async function main() {
   const networkAddress = process.env.NETWORK_ADDRESS ? process.env.NETWORK_ADDRESS : 'ws://127.0.0.1:9944';
   Cord.ConfigService.set({ submitTxResolveOn: Cord.Chain.IS_IN_BLOCK })
-  //await Cord.connect(networkAddress)
 
-  let connName = "random";
-  await Cord.connect(networkAddress, connName);
-  const api = Cord.ConfigService.get(connName);
+  let network = "api-1";
+  await Cord.connect(networkAddress, network);
+  const api = Cord.ConfigService.get(network);
 
   const devAuthorIdentity = Cord.Utils.Crypto.makeKeypairFromUri(
     process.env.ANCHOR_URI ? process.env.ANCHOR_URI : '//Alice',
@@ -27,24 +26,24 @@ async function main() {
   console.log(
     `🔐 Network Member (${devAuthorIdentity.type}): ${devAuthorIdentity.address}`
   )
-  await addNetworkMember(devAuthorIdentity, networkAuthorIdentity.address, connName)
+  await addNetworkMember(devAuthorIdentity, networkAuthorIdentity.address, network)
   console.log('✅ Network Membership Approved! 🎉\n')
 
   const { mnemonic: chainSpaceAdminMnemonic, document: chainSpaceAdminDid } =
-    await createDid(networkAuthorIdentity, connName)
+    await createDid(networkAuthorIdentity, network)
   const chainSpaceAdminKeys = Cord.Utils.Keys.generateKeypairs(chainSpaceAdminMnemonic, 'sr25519')
   console.log(
     `🔐  Network Score Admin (${chainSpaceAdminDid.authentication[0].type}): ${chainSpaceAdminDid.uri}`
   )
   const { mnemonic: networkProviderMnemonic, document: networkProviderDid } =
-    await createDid(networkAuthorIdentity, connName)
+    await createDid(networkAuthorIdentity, network)
   const networkProviderKeys = Cord.Utils.Keys.generateKeypairs(networkProviderMnemonic, 'sr25519')
   console.log(
     `🔐  Network Participant (Provider) (${networkProviderDid.authentication[0].type}): ${networkProviderDid.uri}`
   )
 
   const { mnemonic: networkAuthorMnemonic, document: networkAuthorDid } =
-    await createDid(networkAuthorIdentity, connName)
+    await createDid(networkAuthorIdentity, network)
   const networkAuthorKeys = Cord.Utils.Keys.generateKeypairs(networkAuthorMnemonic, 'sr25519')
   console.log(
     `🔐 Network Author (API -> Node) (${networkAuthorDid.authentication[0].type}): ${networkAuthorDid.uri}`
@@ -70,7 +69,7 @@ async function main() {
 
   console.log(`\n🌐  Network Score Chain Space Creation `)
   const spaceProperties = await Cord.ChainSpace.buildFromProperties(
-    chainSpaceAdminDid.uri, {connName}
+    chainSpaceAdminDid.uri, {network}
   )
   console.dir(spaceProperties, {
     depth: null,
@@ -85,7 +84,7 @@ async function main() {
       signature: chainSpaceAdminKeys.authentication.sign(data),
       keyType: chainSpaceAdminKeys.authentication.type,
     }),
-    connName
+    network
   )
   console.log('✅ Chain Space created! 🎉')
 
@@ -93,7 +92,7 @@ async function main() {
     devAuthorIdentity,
     chainSpace.uri,
     1000,
-    connName
+    network
   )
 
   console.log(`\n🌐  Chain Space Authorization (Author) `)
@@ -104,7 +103,7 @@ async function main() {
       networkAuthorDid.uri,
       permission,
       chainSpaceAdminDid.uri,
-      connName
+      network
     )
   console.dir(spaceAuthProperties, {
     depth: null,
@@ -119,14 +118,14 @@ async function main() {
       signature: chainSpaceAdminKeys.capabilityDelegation.sign(data),
       keyType: chainSpaceAdminKeys.capabilityDelegation.type,
     }),
-    connName
+    network
   )
   console.log(`✅ Chain Space Authorization Approved! 🎉`)
 
   console.log(`\n🌐  Query From Chain - Chain Space `)
   const spaceFromChain = await Cord.ChainSpace.fetchFromChain(
     chainSpace.uri,
-    connName
+    network
   )
   console.dir(spaceFromChain, {
     depth: null,
@@ -136,7 +135,7 @@ async function main() {
   console.log(`\n🌐  Query From Chain - Chain Space Authorization `)
   const spaceAuthFromChain = await Cord.ChainSpace.fetchAuthorizationFromChain(
     delegateAuth as Cord.AuthorizationUri,
-    connName
+    network
   )
   console.dir(spaceAuthFromChain, {
     depth: null,
@@ -183,7 +182,7 @@ async function main() {
     transformedEntry,
     chainSpace.uri,
     networkAuthorDid.uri,
-    connName
+    network
   )
 
   console.log(`\n🌐  Rating Information to Ledger (API -> Ledger) `)
@@ -200,7 +199,7 @@ async function main() {
       signature: networkAuthorKeys.authentication.sign(data),
       keyType: networkAuthorKeys.authentication.type,
     }),
-    connName
+    network
   )
 
   if (Cord.Identifier.isValidIdentifier(ratingUri)) {
@@ -251,7 +250,7 @@ async function main() {
       revokeRatingEntry,
       chainSpace.uri,
       networkAuthorDid.uri,
-      connName
+      network
     )
   console.log(
     `\n🌐  Rating Revoke (Debit) Information to Ledger (API -> Ledger) `
@@ -269,7 +268,7 @@ async function main() {
       signature: networkAuthorKeys.authentication.sign(data),
       keyType: networkAuthorKeys.authentication.type,
     }),
-    connName
+    network
   )
 
   if (Cord.Identifier.isValidIdentifier(revokedRatingUri)) {
@@ -316,7 +315,7 @@ async function main() {
     transformedRevisedEntry,
     chainSpace.uri,
     networkAuthorDid.uri,
-    connName
+    network
   )
 
   console.dir(dispatchRevisedEntry, {
@@ -336,7 +335,7 @@ async function main() {
       signature: networkAuthorKeys.authentication.sign(data),
       keyType: networkAuthorKeys.authentication.type,
     }),
-    connName
+    network
   )
 
   if (Cord.Identifier.isValidIdentifier(revisedRatingUri)) {
@@ -349,7 +348,7 @@ async function main() {
   const ratingEntryFromChain = await Cord.Score.fetchRatingDetailsfromChain(
     revisedRatingUri,
     'Asia/Kolkata',
-    connName
+    network
   )
   console.dir(ratingEntryFromChain, {
     depth: null,
@@ -361,7 +360,7 @@ async function main() {
     await Cord.Score.fetchEntityAggregateScorefromChain(
       ratingContent.entityId,
       Cord.RatingTypeOf.overall,
-      connName
+      network
     )
   console.dir(aggregateScoreFromChain, {
     depth: null,
@@ -370,7 +369,7 @@ async function main() {
 
   console.log(`\n🌐  Query From Chain - Chain Space Usage `)
   const spaceUsageFromChain = await Cord.ChainSpace.fetchFromChain(
-    chainSpace.uri, connName
+    chainSpace.uri, network
   )
   console.dir(spaceUsageFromChain, {
     depth: null,
@@ -380,13 +379,13 @@ async function main() {
 main()
   .then(() => console.log('\nBye! 👋 👋 👋 '))
   .finally(async () => {
-      let connName = "random";
-      await Cord.disconnect(connName);
+      let network = "api-1";
+      await Cord.disconnect(network);
     });
 
 process.on('SIGINT', async () => {
   console.log('\nBye! 👋 👋 👋 \n')
-  let connName = "random";
-  await Cord.disconnect(connName);
+  let network = "api-1";
+  await Cord.disconnect(network);
   process.exit(0)
 })

--- a/demo/src/utils/createAuthorities.ts
+++ b/demo/src/utils/createAuthorities.ts
@@ -6,15 +6,15 @@ import { setTimeout } from "timers/promises";
  * It tries to submit a transaction, and if it fails, it waits a bit and tries again
  * @param tx - The transaction to submit.
  * @param submitter - The account that will be used to sign the transaction.
- * @param connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
 */
 async function failproofSubmit(
   tx: Cord.SubmittableExtrinsic,
   submitter: Cord.KeyringPair,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
   try {
-    await Cord.Chain.signAndSubmitTx(tx, submitter, { connName });
+    await Cord.Chain.signAndSubmitTx(tx, submitter, { network });
   } catch {
     // Try a second time after a small delay and fetching the right nonce.
     const waitingTime = 6_000; // 6 seconds
@@ -25,8 +25,7 @@ async function failproofSubmit(
     console.log("Retrying...");
     // nonce: -1 tells the client to fetch the latest nonce by also checking the tx pool.
     const resignedBatchTx = await tx.signAsync(submitter, { nonce: -1 });
-    console.log("before submitsignedTx", connName);
-    await Cord.Chain.submitSignedTx(resignedBatchTx, {}, connName);
+    await Cord.Chain.submitSignedTx(resignedBatchTx, {}, network);
   }
 }
 
@@ -34,18 +33,18 @@ async function failproofSubmit(
  * It adds an authority to the list of authorities that can submit extrinsics to the chain
  * @param authorAccount - The account that will be used to sign the transaction.
  * @param authority - The address of the authority to add.
- * @param connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  */
 export async function addNetworkMember(
   authorAccount: Cord.KeyringPair,
   authority: Cord.CordAddress,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
-  const api = Cord.ConfigService.get(connName);
+  const api = Cord.ConfigService.get(network);
 
   const callTx = api.tx.networkMembership.nominate(authority, false);
 
   const sudoTx = await api.tx.sudo.sudo(callTx);
 
-  await failproofSubmit(sudoTx, authorAccount, connName);
+  await failproofSubmit(sudoTx, authorAccount, network);
 }

--- a/demo/src/utils/createRegistrar.ts
+++ b/demo/src/utils/createRegistrar.ts
@@ -29,17 +29,21 @@ async function failproofSubmit(
 
 export async function setRegistrar(
   authority: Cord.KeyringPair,
-  registrar: Cord.CordAddress
+  registrar: Cord.CordAddress,
+  connName: string = 'api'
 ) {
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
 
   const callTx = api.tx.identity.addRegistrar(registrar)
   const sudoTx = api.tx.sudo.sudo(callTx)
 
-  await Cord.Chain.signAndSubmitTx(sudoTx, authority)
+  await Cord.Chain.signAndSubmitTx(sudoTx, authority, { connName })
 }
 
-export async function setIdentity(account: Cord.KeyringPair) {
+export async function setIdentity(
+  account: Cord.KeyringPair,
+  connName: string = 'api'
+) {
   const identityInfo = {
     additional: [[null, null]],
     display: {
@@ -56,36 +60,38 @@ export async function setIdentity(account: Cord.KeyringPair) {
     },
   }
 
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
 
   const callTx = api.tx.identity.setIdentity(identityInfo)
 
-  await Cord.Chain.signAndSubmitTx(callTx, account)
+  await Cord.Chain.signAndSubmitTx(callTx, account, { connName })
 
   // await failproofSubmit(callTx, account)
 }
 
 export async function requestJudgement(
   account: Cord.KeyringPair,
-  registrar: Cord.CordAddress
+  registrar: Cord.CordAddress,
+  connName: string = 'api'
 ) {
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
 
   // const identityInfos = await api.query.identity.identityOf(account.address);
   // const identityHash = identityInfos.unwrap().info.hash.toHex();
 
   const callTx = api.tx.identity.requestJudgement(registrar)
 
-  await Cord.Chain.signAndSubmitTx(callTx, account)
+  await Cord.Chain.signAndSubmitTx(callTx, account, { connName })
 
   // await failproofSubmit(callTx, account)
 }
 
 export async function provideJudgement(
   registrar: Cord.KeyringPair,
-  account: Cord.CordAddress
+  account: Cord.CordAddress,
+  connName: string = 'api'
 ) {
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
 
   const identityInfos = await api.query.identity.identityOf(account)
   const [registration, _additionalData] = identityInfos.unwrap()
@@ -96,7 +102,7 @@ export async function provideJudgement(
     'Reasonable',
     identityHash
   )
-  await Cord.Chain.signAndSubmitTx(callTx, registrar)
+  await Cord.Chain.signAndSubmitTx(callTx, registrar, { connName })
 
   // await failproofSubmit(callTx, registrar)
 }

--- a/demo/src/utils/createRegistrar.ts
+++ b/demo/src/utils/createRegistrar.ts
@@ -30,19 +30,19 @@ async function failproofSubmit(
 export async function setRegistrar(
   authority: Cord.KeyringPair,
   registrar: Cord.CordAddress,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
 
   const callTx = api.tx.identity.addRegistrar(registrar)
   const sudoTx = api.tx.sudo.sudo(callTx)
 
-  await Cord.Chain.signAndSubmitTx(sudoTx, authority, { connName })
+  await Cord.Chain.signAndSubmitTx(sudoTx, authority, { network })
 }
 
 export async function setIdentity(
   account: Cord.KeyringPair,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
   const identityInfo = {
     additional: [[null, null]],
@@ -60,11 +60,11 @@ export async function setIdentity(
     },
   }
 
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
 
   const callTx = api.tx.identity.setIdentity(identityInfo)
 
-  await Cord.Chain.signAndSubmitTx(callTx, account, { connName })
+  await Cord.Chain.signAndSubmitTx(callTx, account, { network })
 
   // await failproofSubmit(callTx, account)
 }
@@ -72,16 +72,16 @@ export async function setIdentity(
 export async function requestJudgement(
   account: Cord.KeyringPair,
   registrar: Cord.CordAddress,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
 
   // const identityInfos = await api.query.identity.identityOf(account.address);
   // const identityHash = identityInfos.unwrap().info.hash.toHex();
 
   const callTx = api.tx.identity.requestJudgement(registrar)
 
-  await Cord.Chain.signAndSubmitTx(callTx, account, { connName })
+  await Cord.Chain.signAndSubmitTx(callTx, account, { network })
 
   // await failproofSubmit(callTx, account)
 }
@@ -89,9 +89,9 @@ export async function requestJudgement(
 export async function provideJudgement(
   registrar: Cord.KeyringPair,
   account: Cord.CordAddress,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
 
   const identityInfos = await api.query.identity.identityOf(account)
   const [registration, _additionalData] = identityInfos.unwrap()
@@ -102,7 +102,7 @@ export async function provideJudgement(
     'Reasonable',
     identityHash
   )
-  await Cord.Chain.signAndSubmitTx(callTx, registrar, { connName })
+  await Cord.Chain.signAndSubmitTx(callTx, registrar, { network })
 
   // await failproofSubmit(callTx, registrar)
 }

--- a/demo/src/utils/generateDid.ts
+++ b/demo/src/utils/generateDid.ts
@@ -4,15 +4,19 @@ import { mnemonicGenerate } from '@polkadot/util-crypto'
 /**
  * It creates a DID on chain, and returns the mnemonic and DID document
  * @param submitterAccount - The account that will be used to pay for the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The mnemonic and the DID document.
  */
 export async function createDid(
-  submitterAccount: Cord.CordKeyringPair
+  submitterAccount: Cord.CordKeyringPair,
+  connName: string = 'api',
 ): Promise<{
   mnemonic: string
   document: Cord.DidDocument
 }> {
-  const api = Cord.ConfigService.get('api')
+   
+  console.log("createDid", connName);
+  const api = Cord.ConfigService.get(connName);
 
   const mnemonic = mnemonicGenerate(24)
   const {
@@ -41,10 +45,12 @@ export async function createDid(
     async ({ data }) => ({
       signature: authentication.sign(data),
       keyType: authentication.type,
-    })
+    }),
+    connName,
   )
 
-  await Cord.Chain.signAndSubmitTx(didCreationTx, submitterAccount)
+  console.log("craeteDid2", connName);
+  await Cord.Chain.signAndSubmitTx(didCreationTx, submitterAccount, {connName});
 
   const didUri = Cord.Did.getDidUriFromKey(authentication)
   const encodedDid = await api.call.didApi.query(Cord.Did.toChain(didUri))

--- a/demo/src/utils/generateDid.ts
+++ b/demo/src/utils/generateDid.ts
@@ -4,19 +4,18 @@ import { mnemonicGenerate } from '@polkadot/util-crypto'
 /**
  * It creates a DID on chain, and returns the mnemonic and DID document
  * @param submitterAccount - The account that will be used to pay for the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The mnemonic and the DID document.
  */
 export async function createDid(
   submitterAccount: Cord.CordKeyringPair,
-  connName: string = 'api',
+  network: string = 'api',
 ): Promise<{
   mnemonic: string
   document: Cord.DidDocument
 }> {
    
-  console.log("createDid", connName);
-  const api = Cord.ConfigService.get(connName);
+  const api = Cord.ConfigService.get(network);
 
   const mnemonic = mnemonicGenerate(24)
   const {
@@ -46,11 +45,10 @@ export async function createDid(
       signature: authentication.sign(data),
       keyType: authentication.type,
     }),
-    connName,
+    network,
   )
 
-  console.log("craeteDid2", connName);
-  await Cord.Chain.signAndSubmitTx(didCreationTx, submitterAccount, {connName});
+  await Cord.Chain.signAndSubmitTx(didCreationTx, submitterAccount, {network});
 
   const didUri = Cord.Did.getDidUriFromKey(authentication)
   const encodedDid = await api.call.didApi.query(Cord.Did.toChain(didUri))

--- a/demo/src/utils/generateDidName.ts
+++ b/demo/src/utils/generateDidName.ts
@@ -14,9 +14,9 @@ export async function createDidName(
   submitterAccount: Cord.CordKeyringPair,
   name: Cord.Did.DidName,
   signCallback: Cord.SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<void> {
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
 
   console.log('Did - ', did, name)
   const didNameClaimTx = api.tx.didName.register(name)
@@ -26,7 +26,7 @@ export async function createDidName(
     signCallback,
     submitterAccount.address,
     {},
-    connName
+    network
   )
-  await Cord.Chain.signAndSubmitTx(authorizedDidNameClaimTx, submitterAccount, { connName })
+  await Cord.Chain.signAndSubmitTx(authorizedDidNameClaimTx, submitterAccount, { network })
 }

--- a/demo/src/utils/generateDidName.ts
+++ b/demo/src/utils/generateDidName.ts
@@ -6,15 +6,17 @@ import * as Cord from '@cord.network/sdk'
  * @param submitterAccount - The account that will be used to sign and submit the extrinsic.
  * @param name - The name you want to register.
  * @param signCallback - A callback function that will be called when the transaction needs to be
+ * 
  * signed.
  */
 export async function createDidName(
   did: Cord.DidUri,
   submitterAccount: Cord.CordKeyringPair,
   name: Cord.Did.DidName,
-  signCallback: Cord.SignExtrinsicCallback
+  signCallback: Cord.SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<void> {
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
 
   console.log('Did - ', did, name)
   const didNameClaimTx = api.tx.didName.register(name)
@@ -22,7 +24,9 @@ export async function createDidName(
     did,
     didNameClaimTx,
     signCallback,
-    submitterAccount.address
+    submitterAccount.address,
+    {},
+    connName
   )
-  await Cord.Chain.signAndSubmitTx(authorizedDidNameClaimTx, submitterAccount)
+  await Cord.Chain.signAndSubmitTx(authorizedDidNameClaimTx, submitterAccount, { connName })
 }

--- a/demo/src/utils/queryDidName.ts
+++ b/demo/src/utils/queryDidName.ts
@@ -4,11 +4,14 @@ import * as Cord from '@cord.network/sdk'
 /**
  * It queries the owner of the provided DID name, and then prints the URI of the DID document
  * @param didName - The DID name to resolve.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  */
 export async function getDidDocFromName(
-  didName: Cord.Did.DidName
+  didName: Cord.Did.DidName,
+  connName: string = 'api'
 ): Promise<void> {
-  const api = Cord.ConfigService.get('api')
+  const api = Cord.ConfigService.get(connName)
   console.log(`\n❄️  Resolve DID name ${didName} `)
 
   // Query the owner of the provided didName.

--- a/demo/src/utils/queryDidName.ts
+++ b/demo/src/utils/queryDidName.ts
@@ -4,14 +4,14 @@ import * as Cord from '@cord.network/sdk'
 /**
  * It queries the owner of the provided DID name, and then prints the URI of the DID document
  * @param didName - The DID name to resolve.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  */
 export async function getDidDocFromName(
   didName: Cord.Did.DidName,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<void> {
-  const api = Cord.ConfigService.get(connName)
+  const api = Cord.ConfigService.get(network)
   console.log(`\n❄️  Resolve DID name ${didName} `)
 
   // Query the owner of the provided didName.

--- a/packages/asset/src/Asset.chain.ts
+++ b/packages/asset/src/Asset.chain.ts
@@ -25,10 +25,10 @@ import { SDKErrors } from '@cord.network/utils'
 
 export async function isAssetStored(
   assetUri: AssetUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<boolean> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const identifier = uriToIdentifier(assetUri)
 
@@ -51,10 +51,10 @@ export async function prepareCreateExtrinsic(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName);
+    const api = ConfigService.get(network);
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri);
 
     const tx = api.tx.asset.create(
@@ -69,7 +69,7 @@ export async function prepareCreateExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     );
 
     return extrinsic;
@@ -87,7 +87,7 @@ export async function dispatchCreateToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
     
@@ -96,13 +96,13 @@ export async function dispatchCreateToChain(
       authorAccount,
       authorizationUri,
       signCallback,
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return assetEntry.uri
@@ -123,10 +123,10 @@ export async function dispatchCreateVcToChain(
   authorizationUri: AuthorizationUri,
   assetEntryUri: AssetUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const tx = api.tx.asset.vcCreate(
@@ -141,13 +141,13 @@ export async function dispatchCreateVcToChain(
       signCallback,
       authorAccount.address,
       {}, 
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return assetEntryUri
@@ -165,10 +165,10 @@ export async function prepareExtrinsic(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
@@ -184,7 +184,7 @@ export async function prepareExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     return extrinsic
@@ -202,7 +202,7 @@ export async function dispatchIssueToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
 
@@ -211,12 +211,12 @@ export async function dispatchIssueToChain(
       authorAccount,
       authorizationUri,
       signCallback,
-      connName
+      network
     ) 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName}
+      { network}
     )
 
     return assetEntry.uri
@@ -234,10 +234,10 @@ export async function prepareVcExtrinsic(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
@@ -253,7 +253,7 @@ export async function prepareVcExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     return extrinsic
@@ -271,7 +271,7 @@ export async function dispatchIssueVcToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
 
@@ -280,12 +280,12 @@ export async function dispatchIssueVcToChain(
       authorAccount,
       authorizationUri, 
       signCallback,
-      connName
+      network
     ) 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return assetEntry.uri
@@ -302,10 +302,10 @@ export async function dispatchTransferToChain(
   assetEntry: IAssetTransfer,
   authorAccount: CordKeyringPair,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const tx = api.tx.asset.transfer(assetEntry.entry, assetEntry.digest)
 
@@ -315,13 +315,13 @@ export async function dispatchTransferToChain(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return `${ASSET_PREFIX}${assetEntry.entry.assetId}:${assetEntry.entry.assetInstanceId}`
@@ -338,10 +338,10 @@ export async function dispatchTransferVcToChain(
   assetEntry: IAssetTransfer,
   authorAccount: CordKeyringPair,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const tx = api.tx.asset.vcTransfer(assetEntry.entry, assetEntry.digest)
 
@@ -351,13 +351,13 @@ export async function dispatchTransferVcToChain(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return `${ASSET_PREFIX}${assetEntry.entry.assetId}:${assetEntry.entry.assetInstanceId}`
@@ -378,16 +378,16 @@ export async function dispatchAssetStatusChangeToChain(
   signCallback: SignExtrinsicCallback,
   opts: {
     assetInstanceId?: string,
-    connName?: string
+    network?: string
   }
 ): Promise<void> {
   try {
     let {
       assetInstanceId,
-      connName = 'api'
+      network = 'api'
     } = opts;
 
-    const api = ConfigService.get(connName);
+    const api = ConfigService.get(network);
     let tx;
     const assetId = uriToIdentifier(assetUri);
     const assetIssuerDid = Did.toChain(assetIssuerDidUri);
@@ -453,13 +453,13 @@ export async function dispatchAssetStatusChangeToChain(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     );
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     );
   } catch (error) {
     const errorMessage =
@@ -478,16 +478,16 @@ export async function dispatchAssetStatusChangeVcToChain(
   signCallback: SignExtrinsicCallback,
   opts: {
     assetInstanceId?: string,
-    connName?: string
+    network?: string
   }
 ): Promise<void> {
   try {
     let {
       assetInstanceId,
-      connName = 'api'
+      network = 'api'
     } = opts;
 
-    const api = ConfigService.get(connName);
+    const api = ConfigService.get(network);
     let tx;
     const assetId = uriToIdentifier(assetUri);
     const assetIssuerDid = Did.toChain(assetIssuerDidUri);
@@ -552,13 +552,13 @@ export async function dispatchAssetStatusChangeVcToChain(
       signCallback,
       authorAccount.address,
       {}, 
-      connName
+      network
     );
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     );
   } catch (error) {
     const errorMessage =

--- a/packages/asset/src/Asset.chain.ts
+++ b/packages/asset/src/Asset.chain.ts
@@ -23,9 +23,12 @@ import { SDKErrors } from '@cord.network/utils'
 
 /* TODO: Write method description, params, return types to all methods */
 
-export async function isAssetStored(assetUri: AssetUri): Promise<boolean> {
+export async function isAssetStored(
+  assetUri: AssetUri,
+  connName: string = 'api'
+): Promise<boolean> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const identifier = uriToIdentifier(assetUri)
 
@@ -47,10 +50,11 @@ export async function prepareCreateExtrinsic(
   assetEntry: IAssetEntry,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api');
+    const api = ConfigService.get(connName);
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri);
 
     const tx = api.tx.asset.create(
@@ -63,7 +67,9 @@ export async function prepareCreateExtrinsic(
       assetEntry.creator,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     );
 
     return extrinsic;
@@ -80,7 +86,8 @@ export async function dispatchCreateToChain(
   assetEntry: IAssetEntry,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
     
@@ -88,10 +95,15 @@ export async function dispatchCreateToChain(
       assetEntry,
       authorAccount,
       authorizationUri,
-      signCallback
+      signCallback,
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    )
 
     return assetEntry.uri
   } catch (error) {
@@ -110,10 +122,11 @@ export async function dispatchCreateVcToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   assetEntryUri: AssetUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const tx = api.tx.asset.vcCreate(
@@ -126,10 +139,16 @@ export async function dispatchCreateVcToChain(
       creator,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {}, 
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    )
 
     return assetEntryUri
   } catch (error) {
@@ -145,10 +164,11 @@ export async function prepareExtrinsic(
   assetEntry: IAssetIssuance,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
@@ -162,7 +182,9 @@ export async function prepareExtrinsic(
       assetEntry.issuer,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
     return extrinsic
@@ -179,12 +201,23 @@ export async function dispatchIssueToChain(
   assetEntry: IAssetIssuance,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
 
-    const extrinsic = await prepareExtrinsic(assetEntry, authorAccount, authorizationUri, signCallback) 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    const extrinsic = await prepareExtrinsic(
+      assetEntry,
+      authorAccount,
+      authorizationUri,
+      signCallback,
+      connName
+    ) 
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName}
+    )
 
     return assetEntry.uri
   } catch (error) {
@@ -200,10 +233,11 @@ export async function prepareVcExtrinsic(
   assetEntry: IAssetIssuance,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
@@ -217,7 +251,9 @@ export async function prepareVcExtrinsic(
       assetEntry.issuer,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
     return extrinsic
@@ -234,12 +270,23 @@ export async function dispatchIssueVcToChain(
   assetEntry: IAssetIssuance,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
 
-    const extrinsic = await prepareVcExtrinsic(assetEntry, authorAccount, authorizationUri, signCallback) 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    const extrinsic = await prepareVcExtrinsic(
+      assetEntry, 
+      authorAccount,
+      authorizationUri, 
+      signCallback,
+      connName
+    ) 
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    )
 
     return assetEntry.uri
   } catch (error) {
@@ -254,10 +301,11 @@ export async function dispatchIssueVcToChain(
 export async function dispatchTransferToChain(
   assetEntry: IAssetTransfer,
   authorAccount: CordKeyringPair,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const tx = api.tx.asset.transfer(assetEntry.entry, assetEntry.digest)
 
@@ -265,10 +313,16 @@ export async function dispatchTransferToChain(
       assetEntry.owner,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    )
 
     return `${ASSET_PREFIX}${assetEntry.entry.assetId}:${assetEntry.entry.assetInstanceId}`
   } catch (error) {
@@ -283,10 +337,11 @@ export async function dispatchTransferToChain(
 export async function dispatchTransferVcToChain(
   assetEntry: IAssetTransfer,
   authorAccount: CordKeyringPair,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AssetUri> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const tx = api.tx.asset.vcTransfer(assetEntry.entry, assetEntry.digest)
 
@@ -294,10 +349,16 @@ export async function dispatchTransferVcToChain(
       assetEntry.owner,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    )
 
     return `${ASSET_PREFIX}${assetEntry.entry.assetId}:${assetEntry.entry.assetInstanceId}`
   } catch (error) {
@@ -315,10 +376,18 @@ export async function dispatchAssetStatusChangeToChain(
   authorAccount: CordKeyringPair,
   newStatus: PalletAssetAssetStatusOf,
   signCallback: SignExtrinsicCallback,
-  assetInstanceId?: string
+  opts: {
+    assetInstanceId?: string,
+    connName?: string
+  }
 ): Promise<void> {
   try {
-    const api = ConfigService.get("api");
+    let {
+      assetInstanceId,
+      connName = 'api'
+    } = opts;
+
+    const api = ConfigService.get(connName);
     let tx;
     const assetId = uriToIdentifier(assetUri);
     const assetIssuerDid = Did.toChain(assetIssuerDidUri);
@@ -382,10 +451,16 @@ export async function dispatchAssetStatusChangeToChain(
       assetIssuerDidUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     );
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount);
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    );
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : JSON.stringify(error);
@@ -401,10 +476,18 @@ export async function dispatchAssetStatusChangeVcToChain(
   authorAccount: CordKeyringPair,
   newStatus: PalletAssetAssetStatusOf,
   signCallback: SignExtrinsicCallback,
-  assetInstanceId?: string
+  opts: {
+    assetInstanceId?: string,
+    connName?: string
+  }
 ): Promise<void> {
   try {
-    const api = ConfigService.get("api");
+    let {
+      assetInstanceId,
+      connName = 'api'
+    } = opts;
+
+    const api = ConfigService.get(connName);
     let tx;
     const assetId = uriToIdentifier(assetUri);
     const assetIssuerDid = Did.toChain(assetIssuerDidUri);
@@ -467,10 +550,16 @@ export async function dispatchAssetStatusChangeVcToChain(
       assetIssuerDidUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {}, 
+      connName
     );
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount);
+    await Chain.signAndSubmitTx(
+      extrinsic,
+      authorAccount,
+      { connName }
+    );
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : JSON.stringify(error);

--- a/packages/asset/src/Asset.ts
+++ b/packages/asset/src/Asset.ts
@@ -41,11 +41,11 @@ export async function buildFromAssetProperties(
     assetInput: IAssetProperties,
     issuer: DidUri,
     spaceUri: SpaceUri,
-    connName: string = 'api'
+    network: string = 'api'
 ): Promise<IAssetEntry> {
   const entryDigest = Crypto.hashObjectAsHexStr(assetInput);
   //  const uint8Hash = new Uint8Array([...Crypto.coToUInt8(entryDigest)]);
-  const api:ApiPromise = ConfigService.get(connName);
+  const api:ApiPromise = ConfigService.get(network);
 
   const scaleEncodedAssetDigest = api
     .createType<H256>("H256", entryDigest)
@@ -89,9 +89,9 @@ export async function buildFromIssueProperties(
   assetQty: number,
   issuer: DidUri,
   space: SpaceUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<IAssetIssuance> {
-  const api:ApiPromise = ConfigService.get(connName);
+  const api:ApiPromise = ConfigService.get(network);
 
   const issuanceEntry = {
     assetId: uriToIdentifier(assetUri),

--- a/packages/asset/src/Asset.ts
+++ b/packages/asset/src/Asset.ts
@@ -25,6 +25,7 @@ import {
   AccountId,
   H256,
   Bytes,
+  ApiPromise,
 } from '@cord.network/types'
 import {
   hashToUri,
@@ -40,10 +41,11 @@ export async function buildFromAssetProperties(
     assetInput: IAssetProperties,
     issuer: DidUri,
     spaceUri: SpaceUri,
+    connName: string = 'api'
 ): Promise<IAssetEntry> {
   const entryDigest = Crypto.hashObjectAsHexStr(assetInput);
   //  const uint8Hash = new Uint8Array([...Crypto.coToUInt8(entryDigest)]);
-  const api = ConfigService.get("api");
+  const api:ApiPromise = ConfigService.get(connName);
 
   const scaleEncodedAssetDigest = api
     .createType<H256>("H256", entryDigest)
@@ -87,8 +89,9 @@ export async function buildFromIssueProperties(
   assetQty: number,
   issuer: DidUri,
   space: SpaceUri,
+  connName: string = 'api'
 ): Promise<IAssetIssuance> {
-  const api = ConfigService.get("api");
+  const api:ApiPromise = ConfigService.get(connName);
 
   const issuanceEntry = {
     assetId: uriToIdentifier(assetUri),
@@ -158,9 +161,9 @@ export async function buildFromTransferProperties(
   };
 
   const issueEntryDigest = Crypto.hashObjectAsHexStr(transferEntry);
-//  const uint8Hash = new Uint8Array([
-//    ...Crypto.coToUInt8(issueEntryDigest),
-//  ]);
+  //  const uint8Hash = new Uint8Array([
+  //    ...Crypto.coToUInt8(issueEntryDigest),
+  //  ]);
 
   const transferDetails: IAssetTransfer = {
     entry: transferEntry,

--- a/packages/chain-space/src/ChainSpace.chain.ts
+++ b/packages/chain-space/src/ChainSpace.chain.ts
@@ -74,7 +74,7 @@ import { Chain } from '@cord.network/network'
  * @example
  * ```typescript
  * const spaceUri = 'space:example_uri';
- * isChainSpaceStored(spaceUri, connName).then(exists => {
+ * isChainSpaceStored(spaceUri, network).then(exists => {
  *   console.log(`Chain Space ${exists ? 'exists' : 'does not exist'} on the blockchain.`);
  * }).catch(error => {
  *   console.error('Error querying Chain Space existence:', error);
@@ -82,16 +82,16 @@ import { Chain } from '@cord.network/network'
  * ```
  *
  * @param spaceUri - The URI of the Chain Space to be checked.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to `true` if the Chain Space exists, or `false` otherwise.
  * @throws {SDKErrors.CordQueryError} - Thrown on error during the blockchain query.
  */
 export async function isChainSpaceStored(
   spaceUri: SpaceUri,
-  connName: string = 'api',
+  network: string = 'api',
   ): Promise<boolean> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const identifier = uriToIdentifier(spaceUri)
     const encoded = await api.query.chainSpace.spaces(identifier)
 
@@ -112,7 +112,7 @@ export async function isChainSpaceStored(
  * @example
  * ```typescript
  * const authorizationUri = 'auth:example_uri';
- * isAuthorizationStored(authorizationUri, connName).then(exists => {
+ * isAuthorizationStored(authorizationUri, network).then(exists => {
  *   console.log(`Authorization ${exists ? 'exists' : 'does not exist'} on the blockchain.`);
  * }).catch(error => {
  *   console.error('Error querying authorization existence:', error);
@@ -120,16 +120,16 @@ export async function isChainSpaceStored(
  * ```
  *
  * @param authorizationUri - The URI of the authorization to check.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to `true` if the authorization exists, `false` otherwise.
  * @throws {SDKErrors.CordQueryError} - Thrown on error during the blockchain query.
  */
 export async function isAuthorizationStored(
   authorizationUri: AuthorizationUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<boolean> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const identifier = uriToIdentifier(authorizationUri)
     const encoded = await api.query.chainSpace.authorizations(identifier)
 
@@ -151,7 +151,7 @@ export async function isAuthorizationStored(
  * ```typescript
  * const spaceDigest = 'example_digest';
  * const creatorUri = 'did:cord:creator_uri';
- * getUriForSpace(spaceDigest, creatorUri, connName).then(({ uri, authorizationUri }) => {
+ * getUriForSpace(spaceDigest, creatorUri, network).then(({ uri, authorizationUri }) => {
  *   console.log(`ChainSpace URI: ${uri}, Authorization URI: ${authorizationUri}`);
  * }).catch(error => {
  *   console.error('Error generating URIs:', error);
@@ -160,16 +160,16 @@ export async function isAuthorizationStored(
  *
  * @param spaceDigest - The digest representing the content or configuration of the ChainSpace.
  * @param creatorUri - The DID URI of the creator of the ChainSpace.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization URI.
  * @internal
  */
 export async function getUriForSpace(
   spaceDigest: SpaceDigest,
   creatorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<ChainSpaceDetails> {
-  const api:ApiPromise = ConfigService.get(connName)
+  const api:ApiPromise = ConfigService.get(network)
   const scaleEncodedSpaceDigest = api
     .createType<H256>('H256', spaceDigest)
     .toU8a()
@@ -212,7 +212,7 @@ export async function getUriForSpace(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param signCallback - The callback function for signing the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 export async function prepareCreateSpaceExtrinsic(
@@ -220,12 +220,11 @@ export async function prepareCreateSpaceExtrinsic(
   creatorUri: DidUri,
   signCallback: SignExtrinsicCallback,
   authorAccount: CordKeyringPair,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
-    console.log("prepareCreateSpaceExtrinsic", connName);
     const tx = api.tx.chainSpace.create(chainSpace.digest)
     const extrinsic = await Did.authorizeTx(
       creatorUri,
@@ -233,7 +232,7 @@ export async function prepareCreateSpaceExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
     return extrinsic;
 
@@ -263,7 +262,7 @@ export async function prepareCreateSpaceExtrinsic(
  * const signCallback: SignExtrinsicCallback = // ... implementation ...
  *
  * try {
- *   const result = await dispatchToChain(chainSpace, creatorUri, authorAccount, signCallback, connName);
+ *   const result = await dispatchToChain(chainSpace, creatorUri, authorAccount, signCallback, network);
  *   console.log('ChainSpace dispatched with URI:', result.uri);
  * } catch (error) {
  *   console.error('Error dispatching ChainSpace:', error);
@@ -274,7 +273,7 @@ export async function prepareCreateSpaceExtrinsic(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
  * @param signCallback - The callback function for signing the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -283,7 +282,7 @@ export async function dispatchToChain(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: SpaceUri; authorization: AuthorizationUri }> {
   const returnObject = {
     uri: chainSpace.uri,
@@ -291,17 +290,16 @@ export async function dispatchToChain(
   }
 
   try {
-    const exists = await isChainSpaceStored(chainSpace.uri, connName)
+    const exists = await isChainSpaceStored(chainSpace.uri, network)
     if (!exists) {
-        console.log("chain-space dispatch to chain", connName)
         const extrinsic = await prepareCreateSpaceExtrinsic(
           chainSpace, 
           creatorUri, 
           signCallback, 
           authorAccount, 
-          connName
+          network
         )
-        await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
+        await Chain.signAndSubmitTx(extrinsic, authorAccount, { network })
     }
     return returnObject
   } catch (error) {
@@ -319,7 +317,7 @@ export async function dispatchToChain(
  * @param parent - The chainspace under which the sub-space will be created.
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param signCallback - The callback function for signing the transaction. 
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 export async function prepareCreateSubSpaceExtrinsic(
@@ -329,10 +327,10 @@ export async function prepareCreateSubSpaceExtrinsic(
   parent: SpaceUri,
   creatorUri: DidUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const tx = api.tx.chainSpace.subspaceCreate(
       chainSpace.digest,
@@ -345,7 +343,7 @@ export async function prepareCreateSubSpaceExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     return extrinsic;
@@ -387,7 +385,7 @@ export async function prepareCreateSubSpaceExtrinsic(
  * @param count - The count of transactions permitted to be performed on the chain for the subspace.
  * @param parent - The chainspace under which the sub-space will be created. 
  * @param signCallback - The callback function for signing the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -398,7 +396,7 @@ export async function dispatchSubspaceCreateToChain(
   count: number,
   parent: SpaceUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: SpaceUri; authorization: AuthorizationUri }> {
   const returnObject = {
     uri: chainSpace.uri,
@@ -413,9 +411,9 @@ export async function dispatchSubspaceCreateToChain(
       parent,
       creatorUri,
       signCallback,
-      connName
+      network
     )
-    await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
+    await Chain.signAndSubmitTx(extrinsic, authorAccount, { network })
 
     return returnObject;
   } catch (error) {
@@ -438,7 +436,7 @@ export async function dispatchSubspaceCreateToChain(
  * const authority = 'authority_account';
  * const spaceUri = 'space:example_uri';
  * const capacity = 100;
- * sudoApproveChainSpace(authority, spaceUri, capacity, connName).then(() => {
+ * sudoApproveChainSpace(authority, spaceUri, capacity, network).then(() => {
  *   console.log('ChainSpace approved successfully');
  * }).catch(error => {
  *   console.error('Error approving ChainSpace:', error);
@@ -448,23 +446,23 @@ export async function dispatchSubspaceCreateToChain(
  * @param authority - The account with sudo privileges to approve the ChainSpace.
  * @param spaceUri - The URI of the ChainSpace to be approved.
  * @param capacity - The approved capacity for the ChainSpace.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @throws {SDKErrors.CordDispatchError} - Thrown on error during the dispatch process.
  */
 export async function sudoApproveChainSpace(
   authority: CordKeyringPair,
   spaceUri: SpaceUri,
   capacity: number,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const spaceId = uriToIdentifier(spaceUri)
 
     const tx = api.tx.chainSpace.approve(spaceId, capacity)
     const sudoExtrinsic = api.tx.sudo.sudo(tx)
 
-    await Chain.signAndSubmitTx(sudoExtrinsic, authority, { connName })
+    await Chain.signAndSubmitTx(sudoExtrinsic, authority, { network })
   } catch (error) {
     throw new SDKErrors.CordDispatchError(
       `Error dispatching to chain:"${error}".`
@@ -483,7 +481,7 @@ export async function sudoApproveChainSpace(
  * const spaceUri = 'space:example_uri';
  * const delegateUri = 'did:example:delegate_uri';
  * const creatorUri = 'did:example:creator_uri';
- * getUriForAuthorization(spaceUri, delegateUri, creatorUri, connName).then(authorizationUri => {
+ * getUriForAuthorization(spaceUri, delegateUri, creatorUri, network).then(authorizationUri => {
  *   console.log(`Authorization URI: ${authorizationUri}`);
  * }).catch(error => {
  *   console.error('Error generating authorization URI:', error);
@@ -493,7 +491,7 @@ export async function sudoApproveChainSpace(
  * @param spaceUri - The URI of the ChainSpace.
  * @param delegateUri - The DID URI of the delegate involved in the authorization.
  * @param creatorUri - The DID URI of the creator of the authorization.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to the unique authorization URI.
  * @internal
  */
@@ -501,9 +499,9 @@ export async function getUriForAuthorization(
   spaceUri: SpaceId,
   delegateUri: DidUri,
   creatorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AuthorizationUri> {
-  const api:ApiPromise = ConfigService.get(connName)
+  const api:ApiPromise = ConfigService.get(network)
 
   const scaleEncodedSpaceId = api
     .createType<Bytes>('Bytes', uriToIdentifier(spaceUri))
@@ -546,7 +544,7 @@ export async function getUriForAuthorization(
  * @param spaceId - The identifier of the space to which the delegate authorization is being added.
  * @param delegateId - The decentralized identifier (DID) of the delegate receiving the authorization.
  * @param authId - The identifier of the specific authorization transaction being constructed.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  *
  * @internal
@@ -556,9 +554,9 @@ function dispatchDelegateAuthorizationTx(
   spaceId: string,
   delegateId: string,
   authId: string,
-  connName: string = 'api'
+  network: string = 'api'
 ) {
-  const api = ConfigService.get(connName)
+  const api = ConfigService.get(network)
 
   switch (permission) {
     case Permission.ASSERT:
@@ -609,7 +607,7 @@ function dispatchDelegateAuthorizationTx(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for delegating permissions.
  * @param signCallback - A callback function that handles the signing of the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to the authorization ID after successful processing by the blockchain.
  * @throws {SDKErrors.CordDispatchError} - Thrown on error during the dispatch process.
  */
@@ -618,7 +616,7 @@ export async function dispatchDelegateAuthorization(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<AuthorizationId> {
   try {
     const spaceId = uriToIdentifier(request.uri)
@@ -630,7 +628,7 @@ export async function dispatchDelegateAuthorization(
       spaceId,
       delegateId,
       delegatorAuthId,
-      connName
+      network
     )
     const extrinsic = await Did.authorizeTx(
       request.delegatorUri as DidUri,
@@ -638,10 +636,10 @@ export async function dispatchDelegateAuthorization(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
+    await Chain.signAndSubmitTx(extrinsic, authorAccount, { network })
 
     return request.authorizationUri
   } catch (error) {
@@ -696,7 +694,7 @@ function decodeSpaceDetailsfromChain(
  * the function throws an error.
  *
  * @param spaceUri - The unique identifier (URI) of the space to be fetched.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise that resolves to the space details if found. The details include information such as
  *          the space URI, creator DID, transaction capacity, and other relevant data.
@@ -707,7 +705,7 @@ function decodeSpaceDetailsfromChain(
  * @example
  * ```typescript
  * const spaceUri = 'space:example_uri';
- * fetchFromChain(spaceUri, connName)
+ * fetchFromChain(spaceUri, network)
  *   .then(spaceDetails => {
  *     console.log('Space Details:', spaceDetails);
  *   })
@@ -722,10 +720,10 @@ function decodeSpaceDetailsfromChain(
  */
 export async function fetchFromChain(
   spaceUri: SpaceUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<ISpaceDetails | null> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const spaceId = uriToIdentifier(spaceUri)
 
     const spaceEntry = await api.query.chainSpace.spaces(spaceId)
@@ -838,7 +836,7 @@ function decodeAuthorizationDetailsfromChain(
  * authorization details are not found or cannot be decoded, the function throws an error.
  *
  * @param authorizationUri - The unique identifier (URI) of the authorization to be fetched.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise that resolves to the authorization details if found. These details are represented as an
  *          `ISpaceAuthorization` object, which includes information such as the space ID, delegate DID, permissions,
@@ -852,7 +850,7 @@ function decodeAuthorizationDetailsfromChain(
  * @example
  * ```typescript
  * const authorizationUri = 'auth:cord:example_id';
- * fetchAuthorizationFromChain(authorizationUri, connName)
+ * fetchAuthorizationFromChain(authorizationUri, network)
  *   .then(authorizationDetails => {
  *     console.log('Authorization Details:', authorizationDetails);
  *   })
@@ -867,10 +865,10 @@ function decodeAuthorizationDetailsfromChain(
  */
 export async function fetchAuthorizationFromChain(
   authorizationUri: AuthorizationUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<ISpaceAuthorization | null> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const authId = uriToIdentifier(authorizationUri)
 
     const authEntry = await api.query.chainSpace.authorizations(authId)
@@ -898,7 +896,7 @@ export async function fetchAuthorizationFromChain(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param signCallback - The callback function for signing the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 
@@ -908,10 +906,10 @@ export async function prepareUpdateTxCapacityExtrinsic(
   creatorUri: DidUri,
   signCallback: SignExtrinsicCallback,
   authorAccount: CordKeyringPair,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const tx = api.tx.chainSpace.updateTransactionCapacitySub(spaceUri.replace('space:cord:', ''), new_capacity)    
     const extrinsic = await Did.authorizeTx(
@@ -920,7 +918,7 @@ export async function prepareUpdateTxCapacityExtrinsic(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
     return extrinsic;
 
@@ -961,7 +959,7 @@ export async function prepareUpdateTxCapacityExtrinsic(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
  * @param signCallback - The callback function for signing the transaction.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -971,7 +969,7 @@ export async function dispatchUpdateTxCapacityToChain(
   authorAccount: CordKeyringPair,
   new_capacity: number,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: SpaceUri; }> {
   const returnObject = {
     uri: space
@@ -984,12 +982,12 @@ export async function dispatchUpdateTxCapacityToChain(
       creatorUri, 
       signCallback, 
       authorAccount,
-      connName
+      network
     )
     await Chain.signAndSubmitTx(
       extrinsic, 
       authorAccount,
-      { connName }
+      { network }
     )
 
     return returnObject;

--- a/packages/chain-space/src/ChainSpace.chain.ts
+++ b/packages/chain-space/src/ChainSpace.chain.ts
@@ -37,7 +37,8 @@ import type {
   SpaceDigest,
   AuthorizationUri,
   SpaceUri,
-  SubmittableExtrinsic
+  SubmittableExtrinsic,
+  ApiPromise
 } from '@cord.network/types'
 import { SDKErrors, DecoderUtils } from '@cord.network/utils'
 import {
@@ -73,7 +74,7 @@ import { Chain } from '@cord.network/network'
  * @example
  * ```typescript
  * const spaceUri = 'space:example_uri';
- * isChainSpaceStored(spaceUri).then(exists => {
+ * isChainSpaceStored(spaceUri, connName).then(exists => {
  *   console.log(`Chain Space ${exists ? 'exists' : 'does not exist'} on the blockchain.`);
  * }).catch(error => {
  *   console.error('Error querying Chain Space existence:', error);
@@ -81,12 +82,16 @@ import { Chain } from '@cord.network/network'
  * ```
  *
  * @param spaceUri - The URI of the Chain Space to be checked.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to `true` if the Chain Space exists, or `false` otherwise.
  * @throws {SDKErrors.CordQueryError} - Thrown on error during the blockchain query.
  */
-export async function isChainSpaceStored(spaceUri: SpaceUri): Promise<boolean> {
+export async function isChainSpaceStored(
+  spaceUri: SpaceUri,
+  connName: string = 'api',
+  ): Promise<boolean> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const identifier = uriToIdentifier(spaceUri)
     const encoded = await api.query.chainSpace.spaces(identifier)
 
@@ -107,7 +112,7 @@ export async function isChainSpaceStored(spaceUri: SpaceUri): Promise<boolean> {
  * @example
  * ```typescript
  * const authorizationUri = 'auth:example_uri';
- * isAuthorizationStored(authorizationUri).then(exists => {
+ * isAuthorizationStored(authorizationUri, connName).then(exists => {
  *   console.log(`Authorization ${exists ? 'exists' : 'does not exist'} on the blockchain.`);
  * }).catch(error => {
  *   console.error('Error querying authorization existence:', error);
@@ -115,14 +120,16 @@ export async function isChainSpaceStored(spaceUri: SpaceUri): Promise<boolean> {
  * ```
  *
  * @param authorizationUri - The URI of the authorization to check.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to `true` if the authorization exists, `false` otherwise.
  * @throws {SDKErrors.CordQueryError} - Thrown on error during the blockchain query.
  */
 export async function isAuthorizationStored(
-  authorizationUri: AuthorizationUri
+  authorizationUri: AuthorizationUri,
+  connName: string = 'api'
 ): Promise<boolean> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const identifier = uriToIdentifier(authorizationUri)
     const encoded = await api.query.chainSpace.authorizations(identifier)
 
@@ -144,7 +151,7 @@ export async function isAuthorizationStored(
  * ```typescript
  * const spaceDigest = 'example_digest';
  * const creatorUri = 'did:cord:creator_uri';
- * getUriForSpace(spaceDigest, creatorUri).then(({ uri, authorizationUri }) => {
+ * getUriForSpace(spaceDigest, creatorUri, connName).then(({ uri, authorizationUri }) => {
  *   console.log(`ChainSpace URI: ${uri}, Authorization URI: ${authorizationUri}`);
  * }).catch(error => {
  *   console.error('Error generating URIs:', error);
@@ -153,14 +160,16 @@ export async function isAuthorizationStored(
  *
  * @param spaceDigest - The digest representing the content or configuration of the ChainSpace.
  * @param creatorUri - The DID URI of the creator of the ChainSpace.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization URI.
  * @internal
  */
 export async function getUriForSpace(
   spaceDigest: SpaceDigest,
-  creatorUri: DidUri
+  creatorUri: DidUri,
+  connName: string = 'api'
 ): Promise<ChainSpaceDetails> {
-  const api = ConfigService.get('api')
+  const api:ApiPromise = ConfigService.get(connName)
   const scaleEncodedSpaceDigest = api
     .createType<H256>('H256', spaceDigest)
     .toU8a()
@@ -203,23 +212,28 @@ export async function getUriForSpace(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param signCallback - The callback function for signing the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 export async function prepareCreateSpaceExtrinsic(
   chainSpace: IChainSpace,
   creatorUri: DidUri,
   signCallback: SignExtrinsicCallback,
-  authorAccount: CordKeyringPair
+  authorAccount: CordKeyringPair,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
+    console.log("prepareCreateSpaceExtrinsic", connName);
     const tx = api.tx.chainSpace.create(chainSpace.digest)
     const extrinsic = await Did.authorizeTx(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
     return extrinsic;
 
@@ -249,7 +263,7 @@ export async function prepareCreateSpaceExtrinsic(
  * const signCallback: SignExtrinsicCallback = // ... implementation ...
  *
  * try {
- *   const result = await dispatchToChain(chainSpace, creatorUri, authorAccount, signCallback);
+ *   const result = await dispatchToChain(chainSpace, creatorUri, authorAccount, signCallback, connName);
  *   console.log('ChainSpace dispatched with URI:', result.uri);
  * } catch (error) {
  *   console.error('Error dispatching ChainSpace:', error);
@@ -260,6 +274,7 @@ export async function prepareCreateSpaceExtrinsic(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
  * @param signCallback - The callback function for signing the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -267,7 +282,8 @@ export async function dispatchToChain(
   chainSpace: IChainSpace,
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<{ uri: SpaceUri; authorization: AuthorizationUri }> {
   const returnObject = {
     uri: chainSpace.uri,
@@ -275,10 +291,17 @@ export async function dispatchToChain(
   }
 
   try {
-    const exists = await isChainSpaceStored(chainSpace.uri)
+    const exists = await isChainSpaceStored(chainSpace.uri, connName)
     if (!exists) {
-        const extrinsic = await prepareCreateSpaceExtrinsic(chainSpace, creatorUri, signCallback, authorAccount)
-        await Chain.signAndSubmitTx(extrinsic, authorAccount)
+        console.log("chain-space dispatch to chain", connName)
+        const extrinsic = await prepareCreateSpaceExtrinsic(
+          chainSpace, 
+          creatorUri, 
+          signCallback, 
+          authorAccount, 
+          connName
+        )
+        await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
     }
     return returnObject
   } catch (error) {
@@ -292,9 +315,11 @@ export async function dispatchToChain(
  * Prepares the creation of a sub-space extrinsic for later dispatch to the blockchain.
  * @param chainSpace - The ChainSpace object containing necessary information for creating the ChainSpace on the blockchain.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
- * @param parent - The chainspace under which the sub-space will be created.
  * @param count - The count of transactions permitted to be performed on the chain for the subspace.
+ * @param parent - The chainspace under which the sub-space will be created.
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
+ * @param signCallback - The callback function for signing the transaction. 
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 export async function prepareCreateSubSpaceExtrinsic(
@@ -303,17 +328,24 @@ export async function prepareCreateSubSpaceExtrinsic(
   count: number,
   parent: SpaceUri,
   creatorUri: DidUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
-    const tx = api.tx.chainSpace.subspaceCreate(chainSpace.digest, count, parent?.replace('space:cord:', ''))
+    const tx = api.tx.chainSpace.subspaceCreate(
+      chainSpace.digest,
+      count,
+      parent?.replace('space:cord:', '')
+    )
     const extrinsic = await Did.authorizeTx(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
     return extrinsic;
@@ -352,7 +384,10 @@ export async function prepareCreateSubSpaceExtrinsic(
  * @param chainSpace - The ChainSpace object containing necessary information for creating the ChainSpace on the blockchain.
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
+ * @param count - The count of transactions permitted to be performed on the chain for the subspace.
+ * @param parent - The chainspace under which the sub-space will be created. 
  * @param signCallback - The callback function for signing the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -362,7 +397,8 @@ export async function dispatchSubspaceCreateToChain(
   authorAccount: CordKeyringPair,
   count: number,
   parent: SpaceUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<{ uri: SpaceUri; authorization: AuthorizationUri }> {
   const returnObject = {
     uri: chainSpace.uri,
@@ -370,16 +406,16 @@ export async function dispatchSubspaceCreateToChain(
   }
 
   try {
-    
     const extrinsic = await prepareCreateSubSpaceExtrinsic(
       chainSpace,
       authorAccount,
       count,
       parent,
       creatorUri,
-      signCallback
+      signCallback,
+      connName
     )
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
 
     return returnObject;
   } catch (error) {
@@ -402,7 +438,7 @@ export async function dispatchSubspaceCreateToChain(
  * const authority = 'authority_account';
  * const spaceUri = 'space:example_uri';
  * const capacity = 100;
- * sudoApproveChainSpace(authority, spaceUri, capacity).then(() => {
+ * sudoApproveChainSpace(authority, spaceUri, capacity, connName).then(() => {
  *   console.log('ChainSpace approved successfully');
  * }).catch(error => {
  *   console.error('Error approving ChainSpace:', error);
@@ -412,21 +448,23 @@ export async function dispatchSubspaceCreateToChain(
  * @param authority - The account with sudo privileges to approve the ChainSpace.
  * @param spaceUri - The URI of the ChainSpace to be approved.
  * @param capacity - The approved capacity for the ChainSpace.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @throws {SDKErrors.CordDispatchError} - Thrown on error during the dispatch process.
  */
 export async function sudoApproveChainSpace(
   authority: CordKeyringPair,
   spaceUri: SpaceUri,
-  capacity: number
+  capacity: number,
+  connName: string = 'api'
 ) {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const spaceId = uriToIdentifier(spaceUri)
 
     const tx = api.tx.chainSpace.approve(spaceId, capacity)
     const sudoExtrinsic = api.tx.sudo.sudo(tx)
 
-    await Chain.signAndSubmitTx(sudoExtrinsic, authority)
+    await Chain.signAndSubmitTx(sudoExtrinsic, authority, { connName })
   } catch (error) {
     throw new SDKErrors.CordDispatchError(
       `Error dispatching to chain:"${error}".`
@@ -445,7 +483,7 @@ export async function sudoApproveChainSpace(
  * const spaceUri = 'space:example_uri';
  * const delegateUri = 'did:example:delegate_uri';
  * const creatorUri = 'did:example:creator_uri';
- * getUriForAuthorization(spaceUri, delegateUri, creatorUri).then(authorizationUri => {
+ * getUriForAuthorization(spaceUri, delegateUri, creatorUri, connName).then(authorizationUri => {
  *   console.log(`Authorization URI: ${authorizationUri}`);
  * }).catch(error => {
  *   console.error('Error generating authorization URI:', error);
@@ -455,15 +493,17 @@ export async function sudoApproveChainSpace(
  * @param spaceUri - The URI of the ChainSpace.
  * @param delegateUri - The DID URI of the delegate involved in the authorization.
  * @param creatorUri - The DID URI of the creator of the authorization.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to the unique authorization URI.
  * @internal
  */
 export async function getUriForAuthorization(
   spaceUri: SpaceId,
   delegateUri: DidUri,
-  creatorUri: DidUri
+  creatorUri: DidUri,
+  connName: string = 'api'
 ): Promise<AuthorizationUri> {
-  const api = ConfigService.get('api')
+  const api:ApiPromise = ConfigService.get(connName)
 
   const scaleEncodedSpaceId = api
     .createType<Bytes>('Bytes', uriToIdentifier(spaceUri))
@@ -506,6 +546,7 @@ export async function getUriForAuthorization(
  * @param spaceId - The identifier of the space to which the delegate authorization is being added.
  * @param delegateId - The decentralized identifier (DID) of the delegate receiving the authorization.
  * @param authId - The identifier of the specific authorization transaction being constructed.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  *
  * @internal
@@ -514,9 +555,10 @@ function dispatchDelegateAuthorizationTx(
   permission: PermissionType,
   spaceId: string,
   delegateId: string,
-  authId: string
+  authId: string,
+  connName: string = 'api'
 ) {
-  const api = ConfigService.get('api')
+  const api = ConfigService.get(connName)
 
   switch (permission) {
     case Permission.ASSERT:
@@ -567,6 +609,7 @@ function dispatchDelegateAuthorizationTx(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for delegating permissions.
  * @param signCallback - A callback function that handles the signing of the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to the authorization ID after successful processing by the blockchain.
  * @throws {SDKErrors.CordDispatchError} - Thrown on error during the dispatch process.
  */
@@ -574,7 +617,8 @@ export async function dispatchDelegateAuthorization(
   request: ISpaceAuthorization,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<AuthorizationId> {
   try {
     const spaceId = uriToIdentifier(request.uri)
@@ -585,16 +629,19 @@ export async function dispatchDelegateAuthorization(
       request.permission,
       spaceId,
       delegateId,
-      delegatorAuthId
+      delegatorAuthId,
+      connName
     )
     const extrinsic = await Did.authorizeTx(
       request.delegatorUri as DidUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(extrinsic, authorAccount, { connName })
 
     return request.authorizationUri
   } catch (error) {
@@ -649,7 +696,8 @@ function decodeSpaceDetailsfromChain(
  * the function throws an error.
  *
  * @param spaceUri - The unique identifier (URI) of the space to be fetched.
- *
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to the space details if found. The details include information such as
  *          the space URI, creator DID, transaction capacity, and other relevant data.
  *
@@ -659,7 +707,7 @@ function decodeSpaceDetailsfromChain(
  * @example
  * ```typescript
  * const spaceUri = 'space:example_uri';
- * fetchFromChain(spaceUri)
+ * fetchFromChain(spaceUri, connName)
  *   .then(spaceDetails => {
  *     console.log('Space Details:', spaceDetails);
  *   })
@@ -673,10 +721,11 @@ function decodeSpaceDetailsfromChain(
  * ```
  */
 export async function fetchFromChain(
-  spaceUri: SpaceUri
+  spaceUri: SpaceUri,
+  connName: string = 'api'
 ): Promise<ISpaceDetails | null> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const spaceId = uriToIdentifier(spaceUri)
 
     const spaceEntry = await api.query.chainSpace.spaces(spaceId)
@@ -789,7 +838,8 @@ function decodeAuthorizationDetailsfromChain(
  * authorization details are not found or cannot be decoded, the function throws an error.
  *
  * @param authorizationUri - The unique identifier (URI) of the authorization to be fetched.
- *
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to the authorization details if found. These details are represented as an
  *          `ISpaceAuthorization` object, which includes information such as the space ID, delegate DID, permissions,
  *          authorization ID, and delegator DID. The function returns `null` if the authorization details are not found
@@ -802,7 +852,7 @@ function decodeAuthorizationDetailsfromChain(
  * @example
  * ```typescript
  * const authorizationUri = 'auth:cord:example_id';
- * fetchAuthorizationFromChain(authorizationUri)
+ * fetchAuthorizationFromChain(authorizationUri, connName)
  *   .then(authorizationDetails => {
  *     console.log('Authorization Details:', authorizationDetails);
  *   })
@@ -816,10 +866,11 @@ function decodeAuthorizationDetailsfromChain(
  * ```
  */
 export async function fetchAuthorizationFromChain(
-  authorizationUri: AuthorizationUri
+  authorizationUri: AuthorizationUri,
+  connName: string = 'api'
 ): Promise<ISpaceAuthorization | null> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authId = uriToIdentifier(authorizationUri)
 
     const authEntry = await api.query.chainSpace.authorizations(authId)
@@ -847,6 +898,7 @@ export async function fetchAuthorizationFromChain(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param signCallback - The callback function for signing the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The prepared extrinsic ready for batch signing and submitting.
  */
 
@@ -855,17 +907,20 @@ export async function prepareUpdateTxCapacityExtrinsic(
   new_capacity: number,
   creatorUri: DidUri,
   signCallback: SignExtrinsicCallback,
-  authorAccount: CordKeyringPair
+  authorAccount: CordKeyringPair,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
 
     const tx = api.tx.chainSpace.updateTransactionCapacitySub(spaceUri.replace('space:cord:', ''), new_capacity)    
     const extrinsic = await Did.authorizeTx(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
     return extrinsic;
 
@@ -906,6 +961,7 @@ export async function prepareUpdateTxCapacityExtrinsic(
  * @param creatorUri - The DID URI of the creator, used to authorize the transaction.
  * @param authorAccount - The blockchain account used for signing and submitting the transaction.
  * @param signCallback - The callback function for signing the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise resolving to an object containing the ChainSpace URI and authorization ID.
  * @throws {SDKErrors.CordDispatchError} - Thrown when there's an error during the dispatch process.
  */
@@ -914,15 +970,27 @@ export async function dispatchUpdateTxCapacityToChain(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   new_capacity: number,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<{ uri: SpaceUri; }> {
   const returnObject = {
     uri: space
   }
 
   try {
-    const extrinsic = await prepareUpdateTxCapacityExtrinsic(space, new_capacity, creatorUri, signCallback, authorAccount)
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    const extrinsic = await prepareUpdateTxCapacityExtrinsic(
+      space, 
+      new_capacity, 
+      creatorUri, 
+      signCallback, 
+      authorAccount,
+      connName
+    )
+    await Chain.signAndSubmitTx(
+      extrinsic, 
+      authorAccount,
+      { connName }
+    )
 
     return returnObject;
   } catch (error) {

--- a/packages/chain-space/src/ChainSpace.ts
+++ b/packages/chain-space/src/ChainSpace.ts
@@ -52,10 +52,10 @@ import { getUriForSpace, getUriForAuthorization } from './ChainSpace.chain.js'
  * creator's DID URI and an optional custom description.
  *
  * @param creatorUri - The decentralized identifier (DID) URI of the entity creating the ChainSpace.
- * @param opts - Optional parameters including chainSpaceDesc & connName options. 
+ * @param opts - Optional parameters including chainSpaceDesc & network options. 
  * @param opts.chainSpaceDesc - (Optional) A custom description to represent the ChainSpace. If not provided, a default
  *        description is generated, incorporating a unique UUID.
- * @param opts.connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param opts.network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise that resolves to an IChainSpace object, encompassing the ChainSpace's identifier, description, hash digest,
  *          creator's DID, and authorization URI.
  *
@@ -64,7 +64,7 @@ import { getUriForSpace, getUriForAuthorization } from './ChainSpace.chain.js'
  * const creatorUri = 'did:cord:creator';
  * const customDesc = 'MyCustomChainSpace';
  *
- * buildFromProperties(creatorUri, {customDesc, connName}).then(chainSpace => {
+ * buildFromProperties(creatorUri, {customDesc, network}).then(chainSpace => {
  *   console.log('Created ChainSpace URI:', chainSpace.uri);
  * }).catch(error => {
  *   console.error('Error creating ChainSpace:', error);
@@ -75,11 +75,10 @@ export async function buildFromProperties(
   creatorUri: DidUri,
   {
     chainSpaceDesc,
-    connName = 'api'
-  }: Partial<{ chainSpaceDesc: string, connName: string }> = {}
+    network = 'api'
+  }: Partial<{ chainSpaceDesc: string, network: string }> = {}
 ): Promise<IChainSpace> {
 
-  console.log("buildFromProperties", connName, chainSpaceDesc);
   const chainSpaceDescription =
     chainSpaceDesc || `ChainSpace v1.${UUID.generate()}`
 
@@ -88,7 +87,7 @@ export async function buildFromProperties(
   const { uri, authorizationUri } = await getUriForSpace(
     chainSpaceHash,
     creatorUri,
-    connName
+    network
   )
 
   return {
@@ -112,7 +111,7 @@ export async function buildFromProperties(
  * @param delegateUri - The decentralized identifier (DID) URI of the delegate, the entity being authorized.
  * @param permission - The type of permission being granted to the delegate, defining their role and actions within the ChainSpace.
  * @param creatorUri - The DID URI of the ChainSpace's creator or owner, responsible for authorizing the delegate.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise that resolves to an ISpaceAuthorization object, encapsulating the details of the granted authorization.
  *
  * @example
@@ -122,7 +121,7 @@ export async function buildFromProperties(
  * const permission = PermissionType.EXAMPLE_PERMISSION;
  * const creatorUri = 'did:example:creatorUri';
  *
- * buildFromAuthorizationProperties(spaceUri, delegateUri, permission, creatorUri, connName)
+ * buildFromAuthorizationProperties(spaceUri, delegateUri, permission, creatorUri, network)
  *   .then(spaceAuth => {
  *     console.log('Authorization URI:', spaceAuth.authorizationUri);
  *   })
@@ -136,13 +135,13 @@ export async function buildFromAuthorizationProperties(
   delegateUri: DidUri,
   permission: PermissionType,
   creatorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<ISpaceAuthorization> {
   const authorizationUri = (await getUriForAuthorization(
     spaceUri,
     delegateUri,
     creatorUri,
-    connName
+    network
   )) as AuthorizationUri
 
   return {

--- a/packages/chain-space/src/ChainSpace.ts
+++ b/packages/chain-space/src/ChainSpace.ts
@@ -52,8 +52,10 @@ import { getUriForSpace, getUriForAuthorization } from './ChainSpace.chain.js'
  * creator's DID URI and an optional custom description.
  *
  * @param creatorUri - The decentralized identifier (DID) URI of the entity creating the ChainSpace.
- * @param chainSpaceDesc - (Optional) A custom description to represent the ChainSpace. If not provided, a default
+ * @param opts - Optional parameters including chainSpaceDesc & connName options. 
+ * @param opts.chainSpaceDesc - (Optional) A custom description to represent the ChainSpace. If not provided, a default
  *        description is generated, incorporating a unique UUID.
+ * @param opts.connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns A promise that resolves to an IChainSpace object, encompassing the ChainSpace's identifier, description, hash digest,
  *          creator's DID, and authorization URI.
  *
@@ -62,7 +64,7 @@ import { getUriForSpace, getUriForAuthorization } from './ChainSpace.chain.js'
  * const creatorUri = 'did:cord:creator';
  * const customDesc = 'MyCustomChainSpace';
  *
- * buildFromProperties(creatorUri, customDesc).then(chainSpace => {
+ * buildFromProperties(creatorUri, {customDesc, connName}).then(chainSpace => {
  *   console.log('Created ChainSpace URI:', chainSpace.uri);
  * }).catch(error => {
  *   console.error('Error creating ChainSpace:', error);
@@ -71,8 +73,13 @@ import { getUriForSpace, getUriForAuthorization } from './ChainSpace.chain.js'
  */
 export async function buildFromProperties(
   creatorUri: DidUri,
-  chainSpaceDesc?: string
+  {
+    chainSpaceDesc,
+    connName = 'api'
+  }: Partial<{ chainSpaceDesc: string, connName: string }> = {}
 ): Promise<IChainSpace> {
+
+  console.log("buildFromProperties", connName, chainSpaceDesc);
   const chainSpaceDescription =
     chainSpaceDesc || `ChainSpace v1.${UUID.generate()}`
 
@@ -80,7 +87,8 @@ export async function buildFromProperties(
 
   const { uri, authorizationUri } = await getUriForSpace(
     chainSpaceHash,
-    creatorUri
+    creatorUri,
+    connName
   )
 
   return {
@@ -104,6 +112,7 @@ export async function buildFromProperties(
  * @param delegateUri - The decentralized identifier (DID) URI of the delegate, the entity being authorized.
  * @param permission - The type of permission being granted to the delegate, defining their role and actions within the ChainSpace.
  * @param creatorUri - The DID URI of the ChainSpace's creator or owner, responsible for authorizing the delegate.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * @returns A promise that resolves to an ISpaceAuthorization object, encapsulating the details of the granted authorization.
  *
  * @example
@@ -113,7 +122,7 @@ export async function buildFromProperties(
  * const permission = PermissionType.EXAMPLE_PERMISSION;
  * const creatorUri = 'did:example:creatorUri';
  *
- * buildFromAuthorizationProperties(spaceUri, delegateUri, permission, creatorUri)
+ * buildFromAuthorizationProperties(spaceUri, delegateUri, permission, creatorUri, connName)
  *   .then(spaceAuth => {
  *     console.log('Authorization URI:', spaceAuth.authorizationUri);
  *   })
@@ -126,12 +135,14 @@ export async function buildFromAuthorizationProperties(
   spaceUri: SpaceUri,
   delegateUri: DidUri,
   permission: PermissionType,
-  creatorUri: DidUri
+  creatorUri: DidUri,
+  connName: string = 'api'
 ): Promise<ISpaceAuthorization> {
   const authorizationUri = (await getUriForAuthorization(
     spaceUri,
     delegateUri,
-    creatorUri
+    creatorUri,
+    connName
   )) as AuthorizationUri
 
   return {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -51,7 +51,6 @@ import * as ConfigService from './Service.js'
 export async function init<K extends Partial<ConfigService.configOpts>>(
   configs?: K
 ): Promise<void> {
-  //console.log("configs in init", configs);
   ConfigService.set(configs || {})
   await cryptoWaitReady()
 }
@@ -75,14 +74,14 @@ export async function init<K extends Partial<ConfigService.configOpts>>(
  * ```
  *
  * @param blockchainRpcWsUrl - WebSocket URL for the CORD blockchain RPC endpoint.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @param apiOpts.noInitWarn
  * @param apiOpts - Additional API connection options.
  * @returns A promise resolving to the ApiPromise instance.
  */
 export async function connect(
   blockchainRpcWsUrl: string,
-  connName: string = 'api',
+  network: string = 'api',
   { noInitWarn = true, ...apiOptions }: Omit<ApiOptions, 'provider'> = {},
 ): Promise<ApiPromise> {
   let connection: ApiPromise;
@@ -102,7 +101,7 @@ export async function connect(
     });
 
     /* Create a connection object with dynamic name at runtime */
-    connectionObject = { [connName]: connection };
+    connectionObject = { [network]: connection };
 
     await init(connectionObject);
 
@@ -112,7 +111,7 @@ export async function connect(
     console.error('Error connecting to blockchain:', error);
     throw error;
   } finally {
-    delete connectionObject[connName];
+    delete connectionObject[network];
   }
 }
 
@@ -127,24 +126,23 @@ export async function connect(
  * import { connect, disconnect } from './CordConfig';
  *
  * const wsUrl = 'ws://localhost:9944';
- * connect(wsUrl).then(() => disconnect(connName)).then(disconnected => {
+ * connect(wsUrl).then(() => disconnect(network)).then(disconnected => {
  *   console.log('Disconnected:', disconnected);
  * }).catch(error => {
  *   console.error('Error:', error);
  * });
  * ```
  * 
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise resolving to a boolean indicating successful disconnection.
  */
 export async function disconnect(
-  connName: string = 'api',
+  network: string = 'api',
 ): Promise<boolean> {
-  console.log("disconnect", connName);
-  if (!ConfigService.isSet(connName)) return false
-  const api = ConfigService.get(connName)
-  ConfigService.unset(connName)
+  if (!ConfigService.isSet(network)) return false
+  const api = ConfigService.get(network)
+  ConfigService.unset(network)
   await api.disconnect()
   return true
 }

--- a/packages/config/src/Service.ts
+++ b/packages/config/src/Service.ts
@@ -53,8 +53,6 @@ let configuration: Partial<configOpts> = { ...defaultConfig }
  * @throws {SDKErrors.BlockchainApiMissingError} | Generic not configured error.
  */
 export function get<K extends keyof configOpts>(configOpt: K): configOpts[K] {
-  //console.log("configuration[configOpt]", configuration[configOpt]);
-  //console.log("configOpt", configOpt);
   if (typeof configuration[configOpt] === 'undefined') {
     switch (configOpt) {
       case configOpt:
@@ -100,7 +98,6 @@ export function set<K extends Partial<configOpts>>(opts: K): void {
  * @param key - The key of the configuration option to reset.
  */
 export function unset<K extends keyof configOpts>(key: K): void {
-  //console.log("unset", defaultConfig, key, configuration[key])
   if (Object.prototype.hasOwnProperty.call(defaultConfig, key)) {
     configuration[key] = defaultConfig[key]
   } else {
@@ -125,6 +122,5 @@ export function unset<K extends keyof configOpts>(key: K): void {
  * @returns `true` if the configuration option is set, otherwise `false`.
  */
 export function isSet<K extends keyof configOpts>(key: K): boolean {
-  //console.log("isSet", key, configuration[key]);
   return typeof configuration[key] !== 'undefined'
 }

--- a/packages/config/src/Service.ts
+++ b/packages/config/src/Service.ts
@@ -53,9 +53,11 @@ let configuration: Partial<configOpts> = { ...defaultConfig }
  * @throws {SDKErrors.BlockchainApiMissingError} | Generic not configured error.
  */
 export function get<K extends keyof configOpts>(configOpt: K): configOpts[K] {
+  //console.log("configuration[configOpt]", configuration[configOpt]);
+  //console.log("configOpt", configOpt);
   if (typeof configuration[configOpt] === 'undefined') {
     switch (configOpt) {
-      case 'api':
+      case configOpt:
         throw new SDKErrors.BlockchainApiMissingError()
       default:
         throw new Error(`GENERIC NOT CONFIGURED ERROR FOR KEY: "${configOpt}"`)
@@ -98,6 +100,7 @@ export function set<K extends Partial<configOpts>>(opts: K): void {
  * @param key - The key of the configuration option to reset.
  */
 export function unset<K extends keyof configOpts>(key: K): void {
+  //console.log("unset", defaultConfig, key, configuration[key])
   if (Object.prototype.hasOwnProperty.call(defaultConfig, key)) {
     configuration[key] = defaultConfig[key]
   } else {
@@ -122,5 +125,6 @@ export function unset<K extends keyof configOpts>(key: K): void {
  * @returns `true` if the configuration option is set, otherwise `false`.
  */
 export function isSet<K extends keyof configOpts>(key: K): boolean {
+  //console.log("isSet", key, configuration[key]);
   return typeof configuration[key] !== 'undefined'
 }

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -22,6 +22,7 @@ import type {
   UriFragment,
   VerificationKeyRelationship,
   CordKeyringPair,
+  ApiPromise,
 } from '@cord.network/types'
 import { verificationKeyTypes } from '@cord.network/types'
 import { Crypto, SDKErrors, ss58Format, Keys, } from '@cord.network/utils'
@@ -320,15 +321,18 @@ export type GetStoreTxSignCallback = (
  * @param input The DID keys and services to store, also accepts DidDocument.
  * @param submitter The address authorized to submit the creation operation.
  * @param sign The sign callback. The authentication key has to be used.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  *
  * @returns The SubmittableExtrinsic for the DID creation operation.
  */
 export async function getStoreTx(
   input: GetStoreTxInput | DidDocument,
   submitter: CordAddress,
-  sign: GetStoreTxSignCallback
+  sign: GetStoreTxSignCallback,
+  connName: string = 'api',
 ): Promise<SubmittableExtrinsic> {
-  const api = ConfigService.get('api')
+  console.log("getStoreTx", connName);
+  const api = ConfigService.get(connName);
 
   const {
     authentication,
@@ -429,6 +433,8 @@ export interface SigningOptions {
  * @param params.txCounter The nonce or txCounter value for this extrinsic, which must be on larger than the current txCounter value of the authorizing DID.
  * @param params.submitter Payment account allowed to submit this extrinsic and cover its fees, which will end up owning any deposit associated with newly created records.
  * @param params.blockNumber Block number for determining the validity period of this authorization. If omitted, the current block number will be fetched from chain.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ *
  * @returns A DID authorized extrinsic that, after signing with the payment account mentioned in the params, is ready for submission.
  */
 export async function generateDidAuthenticatedTx({
@@ -439,8 +445,12 @@ export async function generateDidAuthenticatedTx({
   txCounter,
   submitter,
   blockNumber,
-}: AuthorizeCallInput & SigningOptions): Promise<SubmittableExtrinsic> {
-  const api = ConfigService.get('api')
+}: AuthorizeCallInput & SigningOptions,
+  connName:string = 'api'): Promise<SubmittableExtrinsic> {
+  
+  console.log("generateDidAuthenticatedTx", connName);
+  
+  const api:ApiPromise = ConfigService.get(connName)
   const signableCall =
     api.registry.createType<PalletDidDidDetailsDidAuthorizedCallOperation>(
       api.tx.did.submitDidCall.meta.args[0].type.toString(),

--- a/packages/did/src/Did.chain.ts
+++ b/packages/did/src/Did.chain.ts
@@ -321,7 +321,7 @@ export type GetStoreTxSignCallback = (
  * @param input The DID keys and services to store, also accepts DidDocument.
  * @param submitter The address authorized to submit the creation operation.
  * @param sign The sign callback. The authentication key has to be used.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  *
  * @returns The SubmittableExtrinsic for the DID creation operation.
  */
@@ -329,10 +329,9 @@ export async function getStoreTx(
   input: GetStoreTxInput | DidDocument,
   submitter: CordAddress,
   sign: GetStoreTxSignCallback,
-  connName: string = 'api',
+  network: string = 'api',
 ): Promise<SubmittableExtrinsic> {
-  console.log("getStoreTx", connName);
-  const api = ConfigService.get(connName);
+  const api = ConfigService.get(network);
 
   const {
     authentication,
@@ -433,7 +432,7 @@ export interface SigningOptions {
  * @param params.txCounter The nonce or txCounter value for this extrinsic, which must be on larger than the current txCounter value of the authorizing DID.
  * @param params.submitter Payment account allowed to submit this extrinsic and cover its fees, which will end up owning any deposit associated with newly created records.
  * @param params.blockNumber Block number for determining the validity period of this authorization. If omitted, the current block number will be fetched from chain.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  *
  * @returns A DID authorized extrinsic that, after signing with the payment account mentioned in the params, is ready for submission.
  */
@@ -446,11 +445,9 @@ export async function generateDidAuthenticatedTx({
   submitter,
   blockNumber,
 }: AuthorizeCallInput & SigningOptions,
-  connName:string = 'api'): Promise<SubmittableExtrinsic> {
-  
-  console.log("generateDidAuthenticatedTx", connName);
-  
-  const api:ApiPromise = ConfigService.get(connName)
+  network:string = 'api'): Promise<SubmittableExtrinsic> {
+    
+  const api:ApiPromise = ConfigService.get(network)
   const signableCall =
     api.registry.createType<PalletDidDidDetailsDidAuthorizedCallOperation>(
       api.tx.did.submitDidCall.meta.args[0].type.toString(),

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -93,13 +93,13 @@ function increaseNonce(currentNonce: BN, increment = 1): BN {
  * Normally, this function should not be called directly by SDK users. Nevertheless, in advanced cases where there might be race conditions, this function can be used as the basis on which to build parallel operation queues.
  *
  * @param did The DID data.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The next valid nonce, i.e., the nonce currently stored on the blockchain + 1, wrapping around the max value when reached.
  */
 export async function getNextNonce(
   did: DidUri,
-  connName: string = 'api'): Promise<BN> {
-  const api = ConfigService.get(connName)
+  network: string = 'api'): Promise<BN> {
+  const api = ConfigService.get(network)
   const queried = await api.query.did.did(toChain(did))
   const currentNonce = queried.isSome
     ? documentFromChain(queried).lastTxCounter
@@ -116,7 +116,7 @@ export async function getNextNonce(
  * @param submitterAccount The account to bind the DID operation to (to avoid MitM and replay attacks).
  * @param signingOptions The signing options.
  * @param signingOptions.txCounter The optional DID nonce to include in the operation signatures. By default, it uses the next value of the nonce stored on chain.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * @returns The DID-signed submittable extrinsic.
  */
 export async function authorizeTx(
@@ -129,23 +129,22 @@ export async function authorizeTx(
   }: {
     txCounter?: BN
   } = {}, 
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   const keyRelationship = getKeyRelationshipForTx(extrinsic)
   if (keyRelationship === undefined) {
     throw new SDKErrors.SDKError('No key relationship found for extrinsic')
   }
-  console.log("authorizeTx", connName);
 
   return generateDidAuthenticatedTx({
     did,
     keyRelationship,
     sign,
     call: extrinsic,
-    txCounter: txCounter || (await getNextNonce(did, connName)),
+    txCounter: txCounter || (await getNextNonce(did, network)),
     submitter: submitterAccount,
     },
-    connName
+    network
   )
 }
 
@@ -200,7 +199,7 @@ function groupExtrinsicsByKeyRelationship(
  * @param input.sign The callback to sign the operation.
  * @param input.submitter The account to bind the DID operation to (to avoid MitM and replay attacks).
  * @param input.nonce The optional nonce to use for the first batch, next batches will use incremented value.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns The DID-signed submittable extrinsic.
  */
@@ -219,7 +218,7 @@ export async function authorizeBatch({
   sign: SignExtrinsicCallback
   submitter: CordAddress,
 },
-  connName: string = 'api'
+  network: string = 'api'
   ): Promise<SubmittableExtrinsic> {
   if (extrinsics.length === 0) {
     throw new SDKErrors.DidBatchError(
@@ -234,7 +233,7 @@ export async function authorizeBatch({
   }
 
   const groups = groupExtrinsicsByKeyRelationship(extrinsics)
-  const firstNonce = nonce || (await getNextNonce(did, connName))
+  const firstNonce = nonce || (await getNextNonce(did, network))
 
   const promises = groups.map(async (group, batchIndex) => {
     const list = group.extrinsics
@@ -251,7 +250,7 @@ export async function authorizeBatch({
       txCounter,
       submitter,
       },
-      connName
+      network
       )
   })
   const batches = await Promise.all(promises)

--- a/packages/did/src/DidDetails/FullDidDetails.ts
+++ b/packages/did/src/DidDetails/FullDidDetails.ts
@@ -252,7 +252,7 @@ export async function authorizeBatch({
       submitter,
       },
       connName
-    )
+      )
   })
   const batches = await Promise.all(promises)
 

--- a/packages/network-score/src/Scoring.chain.ts
+++ b/packages/network-score/src/Scoring.chain.ts
@@ -64,7 +64,7 @@ import { SDKErrors, DecoderUtils, DataUtils } from '@cord.network/utils'
  * such as in verifying claims or during audits.
  *
  * @param ratingUri - The URI of the rating entry to be checked. This URI is used to identify the rating in the blockchain.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to a boolean value:
  *    - `true` if the rating is found in the blockchain.
@@ -78,7 +78,7 @@ import { SDKErrors, DecoderUtils, DataUtils } from '@cord.network/utils'
  * const ratingUri = 'ratingUri123';
  *
  * try {
- *   const isStored = await isRatingStored(ratingUri, connName);
+ *   const isStored = await isRatingStored(ratingUri, network);
  *   console.log('Is the rating stored?', isStored);
  * } catch (error) {
  *   console.error('Error checking if rating is stored:', error);
@@ -86,10 +86,10 @@ import { SDKErrors, DecoderUtils, DataUtils } from '@cord.network/utils'
  */
 export async function isRatingStored(
   ratingUri: RatingEntryUri,
-  connName: string = 'api',
+  network: string = 'api',
 ): Promise<boolean> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const identifier = uriToIdentifier(ratingUri)
     const encoded = (await api.query.networkScore.ratingEntries(
       identifier
@@ -118,7 +118,7 @@ export async function isRatingStored(
  * @param authorAccount - The blockchain account of the author, used for signing the transaction.
  * @param authorizationUri - The URI that provides authorization context for the rating entry dispatch.
  * @param signCallback - A callback function for signing the extrinsic (blockchain transaction).
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns - A promise that resolves to the URI of the rating entry. If the entry was already on the chain, it returns the existing URI.
  *
@@ -134,7 +134,7 @@ export async function isRatingStored(
  * const signCallback = async (/* ... parameters ... *\/) => { /* ... signing logic ... *\/ };
  *
  * try {
- *   const entryUri = await dispatchRatingToChain(ratingEntry, authorAccount, authorizationUri, signCallback, connName);
+ *   const entryUri = await dispatchRatingToChain(ratingEntry, authorAccount, authorizationUri, signCallback, network);
  *   console.log('Dispatched Rating Entry URI:', entryUri);
  * } catch (error) {
  *   console.error('Error dispatching rating to chain:', error);
@@ -145,12 +145,12 @@ export async function dispatchRatingToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<RatingEntryUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
-    const exists = await isRatingStored(ratingEntry.entryUri, connName)
+    const exists = await isRatingStored(ratingEntry.entryUri, network)
     if (exists) {
       return ratingEntry.entryUri
     }
@@ -168,13 +168,13 @@ export async function dispatchRatingToChain(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
       )
 
     return ratingEntry.entryUri
@@ -202,7 +202,7 @@ export async function dispatchRatingToChain(
  * @param authorAccount - The blockchain account of the author, used for transaction signing.
  * @param authorizationUri - The URI providing the authorization context for the revocation.
  * @param signCallback - A callback function for signing the extrinsic (blockchain transaction).
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to the URI of the revoked rating entry.
  *
@@ -219,7 +219,7 @@ export async function dispatchRatingToChain(
  * const signCallback = async (/* ... parameters ... *\/) => { /* ... signing logic ... *\/ };
  *
  * try {
- *   const entryUri = await dispatchRevokeRatingToChain(ratingEntry, authorAccount, authorizationUri, signCallback, connName);
+ *   const entryUri = await dispatchRevokeRatingToChain(ratingEntry, authorAccount, authorizationUri, signCallback, network);
  *   console.log('Revoked Rating Entry URI:', entryUri);
  * } catch (error) {
  *   console.error('Error dispatching revocation to chain:', error);
@@ -230,16 +230,16 @@ export async function dispatchRevokeRatingToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<RatingEntryUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
 
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const exists = await isRatingStored(
       ratingEntry.entry.referenceId as RatingEntryUri,
-      connName
+      network
     )
 
     if (!exists) {
@@ -263,13 +263,13 @@ export async function dispatchRevokeRatingToChain(
       signCallback,
       authorAccount.address,
       {},
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return ratingEntry.entryUri
@@ -297,7 +297,7 @@ export async function dispatchRevokeRatingToChain(
  * @param authorAccount - The blockchain account of the author, used for signing the transaction.
  * @param authorizationUri - The URI that provides authorization context for the rating revision dispatch.
  * @param signCallback - A callback function for signing the extrinsic (blockchain transaction).
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to the URI of the revised rating entry.
  *                                      If the entry was already on the chain, it returns the existing URI.
@@ -315,7 +315,7 @@ export async function dispatchRevokeRatingToChain(
  * const signCallback = async (/* ... parameters ... *\/) => { /* ... signing logic ... *\/ };
  *
  * try {
- *   const entryUri = await dispatchReviseRatingToChain(revisedRatingEntry, authorAccount, authorizationUri, signCallback, connName);
+ *   const entryUri = await dispatchReviseRatingToChain(revisedRatingEntry, authorAccount, authorizationUri, signCallback, network);
  *   console.log('Revised Rating Entry URI:', entryUri);
  * } catch (error) {
  *   console.error('Error dispatching revised rating to chain:', error);
@@ -326,16 +326,16 @@ export async function dispatchReviseRatingToChain(
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
   signCallback: SignExtrinsicCallback,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<RatingEntryUri> {
   try {
-    const api = ConfigService.get(connName)
+    const api = ConfigService.get(network)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
     const refEntryId: RatingEntryId = uriToIdentifier(
       ratingEntry.entry.referenceId
     )
 
-    const exists = await isRatingStored(ratingEntry.entryUri, connName)
+    const exists = await isRatingStored(ratingEntry.entryUri, network)
     if (exists) {
       return ratingEntry.entryUri
     }
@@ -354,13 +354,13 @@ export async function dispatchReviseRatingToChain(
       signCallback,
       authorAccount.address,
       {}, 
-      connName
+      network
     )
 
     await Chain.signAndSubmitTx(
       extrinsic,
       authorAccount,
-      { connName }
+      { network }
     )
 
     return ratingEntry.entryUri
@@ -524,7 +524,7 @@ function decodeEntryDetailsfromChain(
  *
  * @param ratingUri - The URI of the rating entry to be fetched from the blockchain.
  * @param [timeZone='GMT'] - The timezone to be used for date and time conversions (default is 'GMT').
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to the decoded rating entry details or null if not found.
  *
@@ -532,7 +532,7 @@ function decodeEntryDetailsfromChain(
  * // Example usage of the function
  * const ratingUri = 'ratingUri123';
  *
- * fetchRatingDetailsfromChain(ratingUri, 'GMT', connName)
+ * fetchRatingDetailsfromChain(ratingUri, 'GMT', network)
  *   .then(entryDetails => {
  *     if (entryDetails) {
  *       console.log('Rating Entry Details:', entryDetails);
@@ -547,9 +547,9 @@ function decodeEntryDetailsfromChain(
 export async function fetchRatingDetailsfromChain(
   ratingUri: RatingEntryUri,
   timeZone = 'GMT',
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<IRatingChainStatus | null> {
-  const api = ConfigService.get(connName)
+  const api = ConfigService.get(network)
   const rtngId = uriToIdentifier(ratingUri)
 
   const chainEntry = await api.query.networkScore.ratingEntries(rtngId)
@@ -577,7 +577,7 @@ export async function fetchRatingDetailsfromChain(
  *
  * @param entity - The identifier of the entity for which aggregate scores are to be fetched.
  * @param [ratingType] - (Optional) The specific rating type to fetch the aggregate score for.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to an array of aggregate score objects, or null if no data is found.
  *
@@ -586,7 +586,7 @@ export async function fetchRatingDetailsfromChain(
  * const entityId = 'entity123';
  * const ratingType = RatingTypeOf.overall;
  *
- * fetchEntityAggregateScorefromChain(entityId, ratingType, connName)
+ * fetchEntityAggregateScorefromChain(entityId, ratingType, network)
  *   .then(aggregateScores => {
  *     if (aggregateScores) {
  *       console.log('Aggregate Scores:', aggregateScores);
@@ -601,9 +601,9 @@ export async function fetchRatingDetailsfromChain(
 export async function fetchEntityAggregateScorefromChain(
   entity: string,
   ratingType?: RatingTypeOf,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<IAggregateScore[] | null> {
-  const api:ApiPromise = ConfigService.get(connName)
+  const api:ApiPromise = ConfigService.get(network)
   const decodedEntries: IAggregateScore[] = []
 
   if (ratingType !== undefined) {

--- a/packages/network-score/src/Scoring.ts
+++ b/packages/network-score/src/Scoring.ts
@@ -57,6 +57,7 @@ import type {
   SpaceId,
   HexString,
   DidSignature,
+  ApiPromise,
 } from '@cord.network/types'
 import {
   isDidSignature,
@@ -164,6 +165,8 @@ async function digestSignature(
  * @param entryMsgId - The message ID associated with the rating entry.
  * @param chainSpace - The identifier of the chain space where the rating is stored.
  * @param providerUri - The DID URI of the provider associated with the rating entry.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to the unique URI of the rating entry.
  *
  * @throws {Error} Throws an error if there's an issue with generating the URI.
@@ -175,9 +178,10 @@ export async function getUriForRatingEntry(
   entityId: string,
   entryMsgId: string,
   chainSpace: SpaceId,
-  providerUri: DidUri
+  providerUri: DidUri,
+  connName: string = 'api'
 ): Promise<RatingEntryUri> {
-  const api = ConfigService.get('api')
+  const api: ApiPromise = ConfigService.get(connName)
   const scaleEncodedRatingEntryDigest = api
     .createType<H256>('H256', entryDigest)
     .toU8a()
@@ -261,6 +265,8 @@ function validateHexString(entryDigest: string): void {
  * @param providerUri - The DID URI of the provider associated with the rating entry.
  * @param authorUri - The DID URI of the author who signed the rating entry.
  * @param authorSig - The digital signature of the author.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to an object containing the rating entry URI and its details.
  *
  * @internal
@@ -271,14 +277,19 @@ async function createRatingObject(
   messageId: string,
   chainSpace: SpaceUri,
   providerUri: DidUri,
-  authorUri: DidUri
+  authorUri: DidUri,
+  connName: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: any }> {
+
+  console.log("createRatingObject", connName);
+
   const ratingUri = await getUriForRatingEntry(
     entryDigest,
     entityId,
     messageId,
     chainSpace,
-    providerUri
+    providerUri,
+    connName
   )
 
   return {
@@ -309,6 +320,7 @@ async function createRatingObject(
  *                             This is used for signing the rating and linking it to its author.
  * @param signCallback - A callback function that will be used for signing the rating.
  *                                      This function should adhere to the necessary cryptographic standards for signature generation.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to an object containing:
  *    - `uri`: A unique URI representing the rating entry on the blockchain.
@@ -336,7 +348,7 @@ async function createRatingObject(
  * const authorUri = 'did:example:author123';
  *
  * try {
- *   const result = await buildFromRatingProperties(ratingEntry, chainSpace, authorUri, signCallback);
+ *   const result = await buildFromRatingProperties(ratingEntry, chainSpace, authorUri, signCallback, connName);
  *   console.log('Rating entry URI:', result.uri);
  *   console.log('Rating entry details:', result.details);
  * } catch (error) {
@@ -346,10 +358,12 @@ async function createRatingObject(
 export async function buildFromRatingProperties(
   rating: IRatingEntry,
   chainSpace: SpaceUri,
-  authorUri: DidUri
+  authorUri: DidUri,
+  connName: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     //validateRatingContent(rating.entry)
+    console.log("buildFromRatingProperties", connName);
 
     validateRequiredFields([
       chainSpace,
@@ -368,7 +382,8 @@ export async function buildFromRatingProperties(
       rating.messageId,
       chainSpace,
       Did.getDidUri(rating.entry.providerDid),
-      authorUri
+      authorUri,
+      connName
     )
 
     details.entry = rating.entry
@@ -398,7 +413,8 @@ export async function buildFromRatingProperties(
  *                             This identifier is crucial for associating the revocation with the correct author.
  * @param signCallback - A callback function that handles the signing of the revocation entry.
  *                                      The signature ensures the authenticity and integrity of the revocation request.
- *
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns - A promise that resolves to an object containing:
  *    - `uri`: A unique URI for the revocation entry on the blockchain.
  *    - `details`: An object with the details of the revocation, ready for dispatch to the blockchain.
@@ -415,7 +431,7 @@ export async function buildFromRatingProperties(
  * const authorUri = 'did:example:author123';
  *
  * try {
- *   const result = await buildFromRevokeRatingProperties(ratingRevokeEntry, chainSpace, authorUri, signCallback);
+ *   const result = await buildFromRevokeRatingProperties(ratingRevokeEntry, chainSpace, authorUri, signCallback, connName);
  *   console.log('Revocation entry URI:', result.uri);
  *   console.log('Revocation entry details:', result.details);
  * } catch (error) {
@@ -425,7 +441,8 @@ export async function buildFromRatingProperties(
 export async function buildFromRevokeRatingProperties(
   rating: IRatingRevokeEntry,
   chainSpace: SpaceUri,
-  authorUri: DidUri
+  authorUri: DidUri,
+  connName: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     validateRequiredFields([
@@ -442,7 +459,8 @@ export async function buildFromRevokeRatingProperties(
       rating.entry.messageId,
       chainSpace,
       Did.getDidUri(rating.providerDid),
-      authorUri
+      authorUri,
+      connName
     )
 
     details.entry = rating.entry
@@ -472,6 +490,8 @@ export async function buildFromRevokeRatingProperties(
  *                            This helps in pinpointing the exact location on the blockchain where the rating resides.
  * @param authorUri - The Decentralized Identifier (DID) URI of the author who is revising the rating.
  *                            This identifier is crucial for associating the revocation with the correct author.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise resolving to an object with the following structure:
                               uri: The URI of the rating entry.
                               details: An object containing the details of the rating dispatch, including the entry and other metadata.
@@ -480,7 +500,7 @@ export async function buildFromRevokeRatingProperties(
  *
  * @example
  * try {
- * const result = await buildFromReviseRatingProperties(ratingEntry, chainSpaceUri, authorUri);
+ * const result = await buildFromReviseRatingProperties(ratingEntry, chainSpaceUri, authorUri, connName);
  * console.log("Rating entry URI:", result.uri);
  * console.log("Rating details:", result.details);
  * } catch (error) {
@@ -490,7 +510,8 @@ export async function buildFromRevokeRatingProperties(
 export async function buildFromReviseRatingProperties(
   rating: IRatingEntry,
   chainSpace: SpaceUri,
-  authorUri: DidUri
+  authorUri: DidUri,
+  connName: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     validateRequiredFields([
@@ -511,7 +532,8 @@ export async function buildFromReviseRatingProperties(
       rating.messageId,
       chainSpace,
       Did.getDidUri(rating.entry.providerDid),
-      authorUri
+      authorUri,
+      connName
     )
 
     details.entry = rating.entry

--- a/packages/network-score/src/Scoring.ts
+++ b/packages/network-score/src/Scoring.ts
@@ -165,7 +165,7 @@ async function digestSignature(
  * @param entryMsgId - The message ID associated with the rating entry.
  * @param chainSpace - The identifier of the chain space where the rating is stored.
  * @param providerUri - The DID URI of the provider associated with the rating entry.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise that resolves to the unique URI of the rating entry.
  *
@@ -179,9 +179,9 @@ export async function getUriForRatingEntry(
   entryMsgId: string,
   chainSpace: SpaceId,
   providerUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<RatingEntryUri> {
-  const api: ApiPromise = ConfigService.get(connName)
+  const api: ApiPromise = ConfigService.get(network)
   const scaleEncodedRatingEntryDigest = api
     .createType<H256>('H256', entryDigest)
     .toU8a()
@@ -265,7 +265,7 @@ function validateHexString(entryDigest: string): void {
  * @param providerUri - The DID URI of the provider associated with the rating entry.
  * @param authorUri - The DID URI of the author who signed the rating entry.
  * @param authorSig - The digital signature of the author.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise that resolves to an object containing the rating entry URI and its details.
  *
@@ -278,10 +278,8 @@ async function createRatingObject(
   chainSpace: SpaceUri,
   providerUri: DidUri,
   authorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: any }> {
-
-  console.log("createRatingObject", connName);
 
   const ratingUri = await getUriForRatingEntry(
     entryDigest,
@@ -289,7 +287,7 @@ async function createRatingObject(
     messageId,
     chainSpace,
     providerUri,
-    connName
+    network
   )
 
   return {
@@ -320,7 +318,7 @@ async function createRatingObject(
  *                             This is used for signing the rating and linking it to its author.
  * @param signCallback - A callback function that will be used for signing the rating.
  *                                      This function should adhere to the necessary cryptographic standards for signature generation.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns - A promise that resolves to an object containing:
  *    - `uri`: A unique URI representing the rating entry on the blockchain.
@@ -348,7 +346,7 @@ async function createRatingObject(
  * const authorUri = 'did:example:author123';
  *
  * try {
- *   const result = await buildFromRatingProperties(ratingEntry, chainSpace, authorUri, signCallback, connName);
+ *   const result = await buildFromRatingProperties(ratingEntry, chainSpace, authorUri, signCallback, network);
  *   console.log('Rating entry URI:', result.uri);
  *   console.log('Rating entry details:', result.details);
  * } catch (error) {
@@ -359,11 +357,10 @@ export async function buildFromRatingProperties(
   rating: IRatingEntry,
   chainSpace: SpaceUri,
   authorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     //validateRatingContent(rating.entry)
-    console.log("buildFromRatingProperties", connName);
 
     validateRequiredFields([
       chainSpace,
@@ -383,7 +380,7 @@ export async function buildFromRatingProperties(
       chainSpace,
       Did.getDidUri(rating.entry.providerDid),
       authorUri,
-      connName
+      network
     )
 
     details.entry = rating.entry
@@ -413,7 +410,7 @@ export async function buildFromRatingProperties(
  *                             This identifier is crucial for associating the revocation with the correct author.
  * @param signCallback - A callback function that handles the signing of the revocation entry.
  *                                      The signature ensures the authenticity and integrity of the revocation request.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns - A promise that resolves to an object containing:
  *    - `uri`: A unique URI for the revocation entry on the blockchain.
@@ -431,7 +428,7 @@ export async function buildFromRatingProperties(
  * const authorUri = 'did:example:author123';
  *
  * try {
- *   const result = await buildFromRevokeRatingProperties(ratingRevokeEntry, chainSpace, authorUri, signCallback, connName);
+ *   const result = await buildFromRevokeRatingProperties(ratingRevokeEntry, chainSpace, authorUri, signCallback, network);
  *   console.log('Revocation entry URI:', result.uri);
  *   console.log('Revocation entry details:', result.details);
  * } catch (error) {
@@ -442,7 +439,7 @@ export async function buildFromRevokeRatingProperties(
   rating: IRatingRevokeEntry,
   chainSpace: SpaceUri,
   authorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     validateRequiredFields([
@@ -460,7 +457,7 @@ export async function buildFromRevokeRatingProperties(
       chainSpace,
       Did.getDidUri(rating.providerDid),
       authorUri,
-      connName
+      network
     )
 
     details.entry = rating.entry
@@ -490,7 +487,7 @@ export async function buildFromRevokeRatingProperties(
  *                            This helps in pinpointing the exact location on the blockchain where the rating resides.
  * @param authorUri - The Decentralized Identifier (DID) URI of the author who is revising the rating.
  *                            This identifier is crucial for associating the revocation with the correct author.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A promise resolving to an object with the following structure:
                               uri: The URI of the rating entry.
@@ -500,7 +497,7 @@ export async function buildFromRevokeRatingProperties(
  *
  * @example
  * try {
- * const result = await buildFromReviseRatingProperties(ratingEntry, chainSpaceUri, authorUri, connName);
+ * const result = await buildFromReviseRatingProperties(ratingEntry, chainSpaceUri, authorUri, network);
  * console.log("Rating entry URI:", result.uri);
  * console.log("Rating details:", result.details);
  * } catch (error) {
@@ -511,7 +508,7 @@ export async function buildFromReviseRatingProperties(
   rating: IRatingEntry,
   chainSpace: SpaceUri,
   authorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<{ uri: RatingEntryUri; details: IRatingDispatch }> {
   try {
     validateRequiredFields([
@@ -533,7 +530,7 @@ export async function buildFromReviseRatingProperties(
       chainSpace,
       Did.getDidUri(rating.entry.providerDid),
       authorUri,
-      connName
+      network
     )
 
     details.entry = rating.entry

--- a/packages/network/src/chain/Chain.ts
+++ b/packages/network/src/chain/Chain.ts
@@ -162,12 +162,16 @@ export async function getMaxBatchable(
  *
  * @param tx The SubmittableExtrinsic to be submitted. Most transactions need to be signed, this must be done beforehand.
  * @param opts Allows overwriting criteria for resolving/rejecting the transaction result subscription promise. These options take precedent over configuration via the ConfigService.
+ * @param opts.connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'.
+ * 
  * @returns A promise which can be used to track transaction status.
  * If resolved, this promise returns ISubmittableResult that has led to its resolution.
  */
+// TODO: Below function works correctly even when connName is passed as second paramter from failSubmitProof?
 export async function submitSignedTx(
   tx: SubmittableExtrinsic,
-  opts: Partial<SubscriptionPromise.Options> = {}
+  opts: Partial<SubscriptionPromise.Options> = {},
+  connName: string = 'api'
 ): Promise<ISubmittableResult> {
   const {
     resolveOn = defaultResolveOn(),
@@ -175,7 +179,9 @@ export async function submitSignedTx(
       EXTRINSIC_FAILED(result) || IS_ERROR(result),
   } = opts
 
-  const api = ConfigService.get('api')
+  console.log("opts", opts);
+  console.log("submitSignedTx", connName);
+  const api = ConfigService.get(connName)
   if (!api.hasSubscriptions) {
     throw new SDKErrors.SubscriptionsNotSupportedError()
   }
@@ -223,8 +229,10 @@ export const dispatchTx = submitSignedTx
  *
  * @param tx The generated unsigned SubmittableExtrinsic to submit.
  * @param signer The [[CordKeyringPair]] used to sign the tx.
- * @param opts - Optional parameters including nonce and subscription options.
+ * @param opts - Optional parameters including nonce, connName and subscription options.
  * @param opts.nonce Optional nonce value for the transaction.
+ * @param opts.connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'.
+ * 
  * @returns Promise result of executing the extrinsic, of type ISubmittableResult.
  */
 export async function signAndSubmitTx(
@@ -232,9 +240,12 @@ export async function signAndSubmitTx(
   signer: KeyringPair,
   {
     nonce = -1,
+    connName = 'api',
     ...opts
-  }: Partial<SubscriptionPromise.Options> & Partial<{ nonce: AnyNumber }> = {}
+  }: Partial<SubscriptionPromise.Options> & Partial<{ nonce: AnyNumber }> & Partial<{ connName: string }>= {},
 ): Promise<ISubmittableResult> {
+  console.log("signAndSubmitTx", connName);
   const signedTx = await tx.signAsync(signer, { nonce })
-  return submitSignedTx(signedTx, opts)
+  // TODO: Should connName be inside opts?
+  return submitSignedTx(signedTx, opts, connName)
 }

--- a/packages/network/src/chain/Chain.ts
+++ b/packages/network/src/chain/Chain.ts
@@ -162,16 +162,15 @@ export async function getMaxBatchable(
  *
  * @param tx The SubmittableExtrinsic to be submitted. Most transactions need to be signed, this must be done beforehand.
  * @param opts Allows overwriting criteria for resolving/rejecting the transaction result subscription promise. These options take precedent over configuration via the ConfigService.
- * @param opts.connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * 
  * @returns A promise which can be used to track transaction status.
  * If resolved, this promise returns ISubmittableResult that has led to its resolution.
  */
-// TODO: Below function works correctly even when connName is passed as second paramter from failSubmitProof?
 export async function submitSignedTx(
   tx: SubmittableExtrinsic,
   opts: Partial<SubscriptionPromise.Options> = {},
-  connName: string = 'api'
+  network: string = 'api'
 ): Promise<ISubmittableResult> {
   const {
     resolveOn = defaultResolveOn(),
@@ -179,9 +178,7 @@ export async function submitSignedTx(
       EXTRINSIC_FAILED(result) || IS_ERROR(result),
   } = opts
 
-  console.log("opts", opts);
-  console.log("submitSignedTx", connName);
-  const api = ConfigService.get(connName)
+  const api = ConfigService.get(network)
   if (!api.hasSubscriptions) {
     throw new SDKErrors.SubscriptionsNotSupportedError()
   }
@@ -229,9 +226,9 @@ export const dispatchTx = submitSignedTx
  *
  * @param tx The generated unsigned SubmittableExtrinsic to submit.
  * @param signer The [[CordKeyringPair]] used to sign the tx.
- * @param opts - Optional parameters including nonce, connName and subscription options.
+ * @param opts - Optional parameters including nonce, network and subscription options.
  * @param opts.nonce Optional nonce value for the transaction.
- * @param opts.connName - The chain connection object which will be used to connect to that particular chain. Defaulted to 'api'.
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'.
  * 
  * @returns Promise result of executing the extrinsic, of type ISubmittableResult.
  */
@@ -240,12 +237,10 @@ export async function signAndSubmitTx(
   signer: KeyringPair,
   {
     nonce = -1,
-    connName = 'api',
+    network = 'api',
     ...opts
-  }: Partial<SubscriptionPromise.Options> & Partial<{ nonce: AnyNumber }> & Partial<{ connName: string }>= {},
+  }: Partial<SubscriptionPromise.Options> & Partial<{ nonce: AnyNumber }> & Partial<{ network: string }>= {},
 ): Promise<ISubmittableResult> {
-  console.log("signAndSubmitTx", connName);
   const signedTx = await tx.signAsync(signer, { nonce })
-  // TODO: Should connName be inside opts?
-  return submitSignedTx(signedTx, opts, connName)
+  return submitSignedTx(signedTx, opts, network)
 }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -217,6 +217,8 @@ export function verifyObjectAgainstSchema(
  *                          to generate the expected schema identifier.
  * @param space - An identifier for the space (context or category) associated with the schema.
  *                         This parameter is part of the criteria for generating the expected schema identifier.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+
  *
  * @throws {SDKErrors.SchemaIdMismatchError} Throws an error if the actual schema identifier ($id) does not
  *         match the expected identifier derived from the schema content, creator's DID, and space identifier.
@@ -228,10 +230,11 @@ export function verifyObjectAgainstSchema(
 export function verifySchemaStructure(
   input: ISchema,
   creator: DidUri,
-  space: SpaceId
+  space: SpaceId,
+  connName: string = 'api'
 ): void {
   verifyObjectAgainstSchema(input, SchemaModel)
-  const uriFromSchema = getUriForSchema(input, creator, space)
+  const uriFromSchema = getUriForSchema(input, creator, space, connName)
   if (uriFromSchema.uri !== input.$id) {
     throw new SDKErrors.SchemaIdMismatchError(uriFromSchema.uri, input.$id)
   }
@@ -285,6 +288,8 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
  *
  * @param spaceUri
  * @param creatorUri
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns - A fully constructed schema object including the schema itself, its cryptographic
  *          digest, the space identifier, and the creator's DID. This object can be utilized for data validation
  *          and various other purposes, serving as a cornerstone in data structuring and management.
@@ -307,7 +312,7 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
  * const spaceId = 'exampleSpaceId';
  *
  * try {
- *   const { schema, digest, space, creator } = buildFromProperties(properties, creatorDid, spaceId);
+ *   const { schema, digest, space, creator } = buildFromProperties(properties, spaceUri, creatorUri, connName);
  *   console.log('Constructed Schema:', schema);
  *   console.log('Schema Digest:', digest);
  *   console.log('Space ID:', space);
@@ -320,13 +325,19 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
 export function buildFromProperties(
   schema: ISchema,
   spaceUri: SpaceUri,
-  creatorUri: DidUri
+  creatorUri: DidUri,
+  connName: string = 'api'
 ): ISchemaDetails {
   const { $id, ...uriSchema } = schema
   uriSchema.additionalProperties = false
   uriSchema.$schema = SchemaModelV1.$id
 
-  const { uri, digest } = getUriForSchema(uriSchema, creatorUri, spaceUri)
+  const { uri, digest } = getUriForSchema(
+    uriSchema,
+    creatorUri,
+    spaceUri,
+    connName
+  )
 
   const schemaType = {
     $id: uri,
@@ -339,7 +350,7 @@ export function buildFromProperties(
     spaceUri,
     creatorUri,
   }
-  verifySchemaStructure(schemaType, creatorUri, spaceUri)
+  verifySchemaStructure(schemaType, creatorUri, spaceUri, connName)
   return schemaDetails
 }
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -217,7 +217,7 @@ export function verifyObjectAgainstSchema(
  *                          to generate the expected schema identifier.
  * @param space - An identifier for the space (context or category) associated with the schema.
  *                         This parameter is part of the criteria for generating the expected schema identifier.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
 
  *
  * @throws {SDKErrors.SchemaIdMismatchError} Throws an error if the actual schema identifier ($id) does not
@@ -231,10 +231,10 @@ export function verifySchemaStructure(
   input: ISchema,
   creator: DidUri,
   space: SpaceId,
-  connName: string = 'api'
+  network: string = 'api'
 ): void {
   verifyObjectAgainstSchema(input, SchemaModel)
-  const uriFromSchema = getUriForSchema(input, creator, space, connName)
+  const uriFromSchema = getUriForSchema(input, creator, space, network)
   if (uriFromSchema.uri !== input.$id) {
     throw new SDKErrors.SchemaIdMismatchError(uriFromSchema.uri, input.$id)
   }
@@ -288,7 +288,7 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
  *
  * @param spaceUri
  * @param creatorUri
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns - A fully constructed schema object including the schema itself, its cryptographic
  *          digest, the space identifier, and the creator's DID. This object can be utilized for data validation
@@ -312,7 +312,7 @@ export function verifySchemaMetadata(metadata: ISchemaMetadata): void {
  * const spaceId = 'exampleSpaceId';
  *
  * try {
- *   const { schema, digest, space, creator } = buildFromProperties(properties, spaceUri, creatorUri, connName);
+ *   const { schema, digest, space, creator } = buildFromProperties(properties, spaceUri, creatorUri, network);
  *   console.log('Constructed Schema:', schema);
  *   console.log('Schema Digest:', digest);
  *   console.log('Space ID:', space);
@@ -326,7 +326,7 @@ export function buildFromProperties(
   schema: ISchema,
   spaceUri: SpaceUri,
   creatorUri: DidUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): ISchemaDetails {
   const { $id, ...uriSchema } = schema
   uriSchema.additionalProperties = false
@@ -336,7 +336,7 @@ export function buildFromProperties(
     uriSchema,
     creatorUri,
     spaceUri,
-    connName
+    network
   )
 
   const schemaType = {
@@ -350,7 +350,7 @@ export function buildFromProperties(
     spaceUri,
     creatorUri,
   }
-  verifySchemaStructure(schemaType, creatorUri, spaceUri, connName)
+  verifySchemaStructure(schemaType, creatorUri, spaceUri, network)
   return schemaDetails
 }
 

--- a/packages/statement/src/Statement.chain.ts
+++ b/packages/statement/src/Statement.chain.ts
@@ -57,6 +57,7 @@ import type {
   IStatementEntry,
   HexString,
   SubmittableExtrinsic,
+  ApiPromise
 } from '@cord.network/types'
 import * as Did from '@cord.network/did'
 import {
@@ -80,6 +81,8 @@ import { blake2AsHex, H256 } from '@cord.network/types'
  *
  * @param digest - The hexadecimal string representing the digest of the statement to check.
  * @param spaceUri - The unique identifier of the space where the statement is expected to be stored.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to `true` if the statement is stored, or `false` otherwise.
  *
  * @example
@@ -87,7 +90,7 @@ import { blake2AsHex, H256 } from '@cord.network/types'
  * const digest = '0x1234abcd...';
  * const spaceUri = 'space:cord:example_uri';
  *
- * isStatementStored(digest, spaceUri)
+ * isStatementStored(digest, spaceUri, connName)
  *   .then(isStored => {
  *     if (isStored) {
  *       console.log('Statement is stored on the blockchain.');
@@ -102,9 +105,10 @@ import { blake2AsHex, H256 } from '@cord.network/types'
  */
 export async function isStatementStored(
   digest: HexString,
-  spaceUri: SpaceId
+  spaceUri: SpaceId,
+  connName: string = 'api'
 ): Promise<boolean> {
-  const api = ConfigService.get('api')
+  const api = ConfigService.get(connName)
   const space = uriToIdentifier(spaceUri)
   const encoded = await api.query.statement.identifierLookup(digest, space)
 
@@ -122,6 +126,8 @@ export async function isStatementStored(
  * @param digest - The hexadecimal string representing the digest of the statement.
  * @param spaceUri - The unique identifier of the space related to the statement.
  * @param creatorUri - The decentralized identifier (DID) URI of the creator of the statement.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns The unique URI that represents the statement on the blockchain.
  *
  * @example
@@ -130,7 +136,7 @@ export async function isStatementStored(
  * const spaceUri = 'space:cord:example_uri';
  * const creatorUri = 'did:cord:creator_uri';
  *
- * const statementUri = getUriForStatement(digest, spaceUri, creatorUri);
+ * const statementUri = getUriForStatement(digest, spaceUri, creatorUri, connName);
  * console.log('Statement URI:', statementUri);
  * ```
  *
@@ -139,9 +145,10 @@ export async function isStatementStored(
 export function getUriForStatement(
   digest: HexString,
   spaceUri: SpaceUri,
-  creatorUri: DidUri
+  creatorUri: DidUri,
+  connName: string = 'api'
 ): StatementUri {
-  const api = ConfigService.get('api')
+  const api:ApiPromise = ConfigService.get(connName)
 
   const scaleEncodedSchema = api.createType<H256>('H256', digest).toU8a()
   const scaleEncodedSpace = api
@@ -180,6 +187,8 @@ export function getUriForStatement(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for the statement.
  * @param signCallback - A callback function that handles the signing of the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns The element URI of the registered statement.
  *
  * @throws {SDKErrors.CordDispatchError} - Thrown when there is an error during the dispatch process,
@@ -195,7 +204,7 @@ export function getUriForStatement(
  * const authorizationUri = 'auth:cord:example_uri';
  * const signCallback = // ... implementation ...
  *
- * dispatchRegisterToChain(stmtEntry, creatorUri, authorAccount, authorizationUri, signCallback)
+ * dispatchRegisterToChain(stmtEntry, creatorUri, authorAccount, authorizationUri, signCallback, connName)
  *   .then(statementUri => {
  *     console.log('Statement registered with URI:', statementUri);
  *   })
@@ -209,7 +218,8 @@ export async function dispatchRegisterToChain(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<StatementUri> {
   try {
     const tx = await prepareExtrinsicToRegister(
@@ -217,10 +227,11 @@ export async function dispatchRegisterToChain(
       creatorUri,
       authorAccount,
       authorizationUri,
-      signCallback
+      signCallback,
+      connName
     )
 
-    await Chain.signAndSubmitTx(tx, authorAccount)
+    await Chain.signAndSubmitTx(tx, authorAccount, { connName })
 
     return stmtEntry.elementUri
   } catch (error) {
@@ -252,7 +263,9 @@ export async function dispatchRegisterToChain(
  * @param {SignExtrinsicCallback} signCallback - The `signCallback` parameter in the `prepareExtrinsic`
  * function is a callback function that is used to sign the extrinsic transaction before it is
  * submitted to the blockchain. This function typically takes care of the signing process using the
- * private key of the account that is authorizing the transaction. It is
+ * private key of the account that is authorizing the transaction.
+ * 
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  *
  * @returns A `SubmittableExtrinsic` is being returned from the `prepareExtrinsic` function.
  */
@@ -261,17 +274,18 @@ export async function prepareExtrinsicToRegister(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
     const schemaId =
       stmtEntry.schemaUri !== undefined
         ? stmtEntry.schemaUri && uriToIdentifier(stmtEntry.schemaUri)
         : undefined
 
-    const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri)
+    const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri, connName)
 
     if (exists) {
       throw new SDKErrors.DuplicateStatementError(
@@ -287,7 +301,9 @@ export async function prepareExtrinsicToRegister(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
     return extrinsic
@@ -315,6 +331,8 @@ export async function prepareExtrinsicToRegister(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for the statement.
  * @param signCallback - A callback function that handles the signing of the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns The element URI of the updated statement.
  *
  * @throws {SDKErrors.CordDispatchError} - Thrown when there is an error during the dispatch process,
@@ -330,7 +348,7 @@ export async function prepareExtrinsicToRegister(
  * const authorizationUri = 'auth:cord:example_uri';
  * const signCallback = // ... implementation ...
  *
- * dispatchUpdateToChain(stmtEntry, creatorUri, authorAccount, authorizationUri, signCallback)
+ * dispatchUpdateToChain(stmtEntry, creatorUri, authorAccount, authorizationUri, signCallback, connName)
  *   .then(statementUri => {
  *     console.log('Statement updated with URI:', statementUri);
  *   })
@@ -344,13 +362,14 @@ export async function dispatchUpdateToChain(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<StatementUri> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
-    const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri)
+    const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri, connName)
 
     if (exists) {
       return stmtEntry.elementUri
@@ -367,10 +386,16 @@ export async function dispatchUpdateToChain(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic, 
+      authorAccount, 
+      { connName }
+    )
 
     return stmtEntry.elementUri
   } catch (error) {
@@ -404,13 +429,18 @@ export async function dispatchUpdateToChain(
  * `dispatchRevokeToChain` function is a callback function that is used to sign the extrinsic before
  * submitting it to the chain. This callback function typically takes care of signing the transaction
  * using the private key of the account associated with the author of the statement.
+ * 
+ * @param connName - An optional chain connection object to be used to connect to a particular chain.
+ * Defaults to 'api'. 
+ * 
  */
 export async function dispatchRevokeToChain(
   statementUri: StatementUri,
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<void> {
   try {
     const tx = await prepareExtrinsicToRevoke(
@@ -418,10 +448,15 @@ export async function dispatchRevokeToChain(
       creatorUri,
       authorAccount,
       authorizationUri,
-      signCallback
+      signCallback,
+      connName
     )
 
-    await Chain.signAndSubmitTx(tx, authorAccount)
+    await Chain.signAndSubmitTx(
+      tx,
+      authorAccount,
+      { connName }
+    )
   } catch (error) {
     throw new SDKErrors.CordDispatchError(
       `Error dispatching to chain: "${error}".`
@@ -443,6 +478,8 @@ export async function dispatchRevokeToChain(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for the statement.
  * @param signCallback - A callback function that handles the signing of the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves once the transaction is successfully processed.
  *
  * @throws {SDKErrors.CordDispatchError} - Thrown when there is an error during the dispatch process,
@@ -456,7 +493,7 @@ export async function dispatchRevokeToChain(
  * const authorizationUri = 'auth:cord:example_uri';
  * const signCallback = // ... implementation ...
  *
- * dispatchRevokeToChain(statementUri, creatorUri, authorAccount, authorizationUri, signCallback)
+ * dispatchRevokeToChain(statementUri, creatorUri, authorAccount, authorizationUri, signCallback, connName)
  *   .then(() => {
  *     console.log('Statement successfully revoked.');
  *   })
@@ -470,10 +507,11 @@ export async function prepareExtrinsicToRevoke(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<SubmittableExtrinsic> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const stmtIdDigest = uriToStatementIdAndDigest(statementUri)
@@ -485,7 +523,9 @@ export async function prepareExtrinsicToRevoke(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
     return extrinsic
@@ -510,6 +550,8 @@ export async function prepareExtrinsicToRevoke(
  * @param authorAccount - The blockchain account used to sign and submit the transaction.
  * @param authorizationUri - The URI of the authorization used for the statement.
  * @param signCallback - A callback function that handles the signing of the transaction.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves once the transaction is successfully processed.
  *
  * @throws {SDKErrors.CordDispatchError} - Thrown when there is an error during the dispatch process,
@@ -523,7 +565,7 @@ export async function prepareExtrinsicToRevoke(
  * const authorizationUri = 'auth:cord:example_uri';
  * const signCallback = // ... implementation ...
  *
- * dispatchRestoreToChain(statementUri, creatorUri, authorAccount, authorizationUri, signCallback)
+ * dispatchRestoreToChain(statementUri, creatorUri, authorAccount, authorizationUri, signCallback, connName)
  *   .then(() => {
  *     console.log('Statement successfully restored.');
  *   })
@@ -537,10 +579,11 @@ export async function dispatchRestoreToChain(
   creatorUri: DidUri,
   authorAccount: CordKeyringPair,
   authorizationUri: AuthorizationUri,
-  signCallback: SignExtrinsicCallback
+  signCallback: SignExtrinsicCallback,
+  connName: string = 'api'
 ): Promise<void> {
   try {
-    const api = ConfigService.get('api')
+    const api = ConfigService.get(connName)
     const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const stmtIdDigest = uriToStatementIdAndDigest(statementUri)
@@ -552,10 +595,16 @@ export async function dispatchRestoreToChain(
       creatorUri,
       tx,
       signCallback,
-      authorAccount.address
+      authorAccount.address,
+      {},
+      connName
     )
 
-    await Chain.signAndSubmitTx(extrinsic, authorAccount)
+    await Chain.signAndSubmitTx(
+      extrinsic, 
+      authorAccount,
+      { connName} 
+    )
   } catch (error) {
     throw new SDKErrors.CordDispatchError(
       `Error dispatching to chain: "${error}".`
@@ -616,6 +665,8 @@ export function decodeStatementDetailsfromChain(
  * It returns the detailed information of the statement, including its digest, space URI, and schema URI.
  *
  * @param identifier - The unique identifier of the statement whose details are being fetched.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to an `IStatementDetails` object containing detailed information about the statement,
  *          or `null` if the statement is not found.
  *
@@ -624,7 +675,7 @@ export function decodeStatementDetailsfromChain(
  * @example
  * ```typescript
  * const statementId = 'example_identifier';
- * getDetailsfromChain(statementId)
+ * getDetailsfromChain(statementId, connName)
  *   .then(statementDetails => {
  *     console.log('Statement Details:', statementDetails);
  *   })
@@ -636,9 +687,10 @@ export function decodeStatementDetailsfromChain(
  * @internal
  */
 export async function getDetailsfromChain(
-  identifier: string
+  identifier: string,
+  connName: string = 'api'
 ): Promise<IStatementDetails | null> {
-  const api = ConfigService.get('api')
+  const api = ConfigService.get(connName)
   const statementId = uriToIdentifier(identifier)
 
   const statementEntry = await api.query.statement.statements(statementId)
@@ -664,6 +716,8 @@ export async function getDetailsfromChain(
  * digest, space URI, creator URI, schema URI (if applicable), and revocation status.
  *
  * @param stmtUri - The URI of the statement whose status is being fetched.
+ * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * 
  * @returns A promise that resolves to an `IStatementStatus` object containing the statement's details,
  *          or `null` if the statement is not found.
  *
@@ -672,7 +726,7 @@ export async function getDetailsfromChain(
  * @example
  * ```typescript
  * const statementUri = 'stmt:cord:example_uri';
- * fetchStatementStatusfromChain(statementUri)
+ * fetchStatementStatusfromChain(statementUri, connName)
  *   .then(statementStatus => {
  *     console.log('Statement Status:', statementStatus);
  *   })
@@ -682,12 +736,13 @@ export async function getDetailsfromChain(
  * ```
  */
 export async function fetchStatementDetailsfromChain(
-  stmtUri: StatementUri
+  stmtUri: StatementUri,
+  connName: string = 'api'
 ): Promise<IStatementStatus | null> {
-  const api = ConfigService.get('api')
+  const api = ConfigService.get(connName)
   const { identifier, digest } = uriToStatementIdAndDigest(stmtUri)
 
-  const statementDetails = await getDetailsfromChain(identifier)
+  const statementDetails = await getDetailsfromChain(identifier, connName)
   if (statementDetails === null) {
     throw new SDKErrors.StatementError(
       `There is no statement with the provided ID "${identifier}" present on the chain.`

--- a/packages/statement/src/Statement.ts
+++ b/packages/statement/src/Statement.ts
@@ -104,7 +104,7 @@ export function verifyDataStructure(input: IStatementEntry): void {
  * @param spaceUri - The URI of the ChainSpace associated with the statement.
  * @param creatorUri - The DID URI of the statement's creator.
  * @param schemaUri - (Optional) The URI of the schema linked to the statement. Defaults to `undefined` if not provided.
- * @param connName - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
+ * @param network - An optional chain connection object to be used to connect to a particular chain. Defaults to 'api'. 
  * 
  * @returns A fully constructed `IStatementEntry` object.
  *
@@ -114,7 +114,7 @@ export function verifyDataStructure(input: IStatementEntry): void {
  * const spaceUri = 'space:cord:example_uri';
  * const creatorUri = 'did:cord:creator_uri';
  * const schemaUri = 'schema:cord:schema_uri';
- * const statementEntry = buildFromProperties(digest, spaceUri, creatorUri, schemaUri, connName);
+ * const statementEntry = buildFromProperties(digest, spaceUri, creatorUri, schemaUri, network);
  * console.log('Statement Entry:', statementEntry);
  * ```
  *
@@ -131,13 +131,13 @@ export function buildFromProperties(
   spaceUri: SpaceUri,
   creatorUri: DidUri,
   schemaUri?: SchemaUri,
-  connName: string = 'api'
+  network: string = 'api'
 ): IStatementEntry {
   const stmtUri = getUriForStatement(
     digest,
     spaceUri,
     creatorUri,
-    connName
+    network
   )
 
   const statement: IStatementEntry = {
@@ -238,7 +238,7 @@ export function isIStatement(input: unknown): input is IStatementEntry {
  * const creatorUri = 'did:cord:creator_uri';
  * const spaceUri = 'space:cord:example_uri';
  * const schemaUri = 'schema:cord:schema_uri';
- * verifyAgainstProperties(stmtUri, digest, { creatorUri, spaceUri, schemaUri, connName} )
+ * verifyAgainstProperties(stmtUri, digest, { creatorUri, spaceUri, schemaUri, network} )
  *   .then(result => {
  *     console.log('Verification result:', result);
  *   })
@@ -262,12 +262,10 @@ export async function verifyAgainstProperties(
       creator,
       spaceuri,
       schemaUri,
-      connName = 'api'
+      network = 'api'
     } = opts;
 
-    console.log("verifyAgainstProperties", connName)
-
-    const statementStatus = await fetchStatementDetailsfromChain(stmtUri, connName)
+    const statementStatus = await fetchStatementDetailsfromChain(stmtUri, network)
 
     if (!statementStatus) {
       return {

--- a/packages/types/src/Statement.ts
+++ b/packages/types/src/Statement.ts
@@ -43,5 +43,5 @@ export type VerifyAgainstPropertiesOptions = {
   creator?: DidUri;
   spaceuri?: SpaceUri;
   schemaUri?: SchemaUri;
-  connName?: string;
+  network?: string;
 };

--- a/packages/types/src/Statement.ts
+++ b/packages/types/src/Statement.ts
@@ -38,3 +38,10 @@ export interface IStatementStatus {
   schemaUri?: string | undefined
   revoked: boolean
 }
+
+export type VerifyAgainstPropertiesOptions = {
+  creator?: DidUri;
+  spaceuri?: SpaceUri;
+  schemaUri?: SchemaUri;
+  connName?: string;
+};


### PR DESCRIPTION
Updated all modules with method docs to support object based network connection & destruction.

For demo below working scripts are updated to demonstrate the same.
- `demo/src/func-test.ts`
- `demo/src/network-score-test.ts`
- `demo/src/asset-tx.ts`

Example Usage:
```typescript

  let network = "api-1";
  await Cord.connect(networkAddress, network);
  const api = Cord.ConfigService.get(network);
  
  const space = await Cord.ChainSpace.dispatchToChain(
    spaceProperties,
    issuerDid.uri,
    networkAuthorityIdentity,
    async ({ data }) => ({
      signature: issuerKeys.authentication.sign(data),
      keyType: issuerKeys.authentication.type,
    }),
    network
  )
  
 ```
 Similarly the disconnect should be made using `api-1` itself.
 Usage of `api-2` for ex. when chain is connected to `api-1` object would result in error.
 
 Where `network` is a optional parameter.

One more minor feature left as `TODO` is having ability to use dynamic variable names for the api without the use of `ApiPromise` type definition externally to avoid type missing warnings at some places.
Ex:
``` typescript
const api_1: ApiPromise = Cord.ConfigService.get(network);
```

The target branch for this PR is `base:multichain`
