### PR TITLE
type-defs: Add new multiruntime shared bundeles

### DIFF
--- a/packages/type-definitions/src/index.ts
+++ b/packages/type-definitions/src/index.ts
@@ -48,5 +48,9 @@ export const typesBundle: OverrideBundleType = {
   spec: {
     cord: sharedBundle,
     cordGraph: sharedBundle,
+    braid: sharedBundle,
+    loom: sharedBundle,
+    weave: sharedBundle,
+    test: sharedBundle,
   },
 }


### PR DESCRIPTION
This change allows DID based ops given that account has sufficient balance.