### PR TITLE
fix: packages/did: throw an error if space already exists

### DIFF
--- a/packages/chain-space/src/ChainSpace.chain.ts
+++ b/packages/chain-space/src/ChainSpace.chain.ts
@@ -273,14 +273,18 @@ export async function dispatchToChain(
     uri: chainSpace.uri,
     authorization: chainSpace.authorizationUri,
   }
-
   try {
     const exists = await isChainSpaceStored(chainSpace.uri)
     if (!exists) {
         const extrinsic = await prepareCreateSpaceExtrinsic(chainSpace, creatorUri, signCallback, authorAccount)
         await Chain.signAndSubmitTx(extrinsic, authorAccount)
+        return returnObject
     }
-    return returnObject
+    else{
+      throw new SDKErrors.CordDispatchError(
+        `Error dispatching to chain: Chainspace already exists.`
+      )
+    }
   } catch (error) {
     throw new SDKErrors.CordDispatchError(
       `Error dispatching to chain: "${error}".`


### PR DESCRIPTION
This pull request addresses an issue where the SDK did not throw an error if a chainspace was already present. The fix ensures that attempting to create a chainspace that already exists will now result in an appropriate error being thrown.This pull request addresses an issue where the SDK did not throw an error if a chainspace was already present. The fix ensures that attempting to create a chainspace that already exists will now result in an appropriate error being thrown.