### PR TITLE
chainspace: Fix authorization-id digest calculation

### DIFF
--- a/packages/chain-space/src/ChainSpace.chain.ts
+++ b/packages/chain-space/src/ChainSpace.chain.ts
@@ -180,7 +180,7 @@ export async function getUriForSpace(
     .toU8a()
 
   const authDigest = blake2AsHex(
-    Uint8Array.from([...scaleEncodedAuthDigest, ...scaleEncodedAuthDelegate])
+    Uint8Array.from([...scaleEncodedAuthDigest, ...scaleEncodedAuthDelegate, ...scaleEncodedAuthDelegate])
   )
 
   const authorizationUri = hashToUri(


### PR DESCRIPTION
Fix the way `authorization-id` is calculated in chain-space.

Important Notice:
- This would be a **_breaking change_** introduced by the commit in `CORD commit d51b425ade0628371c16680f110cfe4a4ad1b75c`.

- If the deployed chain has above commit then make sure to incorporate this fix in deployed SDK as well/ or use the SDK version which has this change.


@amarts @prashant4dev @adi-a11y @Vikastc @RCCodeBase @NiranjanAP