### PR TITLE
schema: Update the regex to handle additional properties

### DIFF
--- a/packages/schema/src/Schema.types.ts
+++ b/packages/schema/src/Schema.types.ts
@@ -112,7 +112,7 @@ export const SchemaModelV1: JsonSchema.Schema & { $id: string } = {
       additionalProperties: false,
       properties: {
         $ref: {
-          pattern: '^schema:cord:m[0-9a-zA-Z]+(#/properties/.+)?$',
+          pattern: '^schema:cord:s[0-9a-zA-Z]+(#/properties/.+)?$',
           format: 'uri',
           type: 'string',
         },


### PR DESCRIPTION
Update the regex to match the prefix of the schema type created. It always starts from `s` currently.