### PR TITLE
Split preparing and submitting of extrinsics

### DIFF
--- a/packages/chain-space/src/ChainSpace.chain.ts
+++ b/packages/chain-space/src/ChainSpace.chain.ts
@@ -95,6 +95,7 @@ export async function isChainSpaceStored(spaceUri: SpaceUri): Promise<boolean> {
   }
 }
 
+
 /**
  * Checks if a given authorization exists on the CORD blockchain.
  *
@@ -130,6 +131,7 @@ export async function isAuthorizationStored(
     )
   }
 }
+
 
 /**
  * Generates unique URIs for a ChainSpace and its associated authorization.
@@ -194,6 +196,7 @@ export async function getUriForSpace(
   return chainSpaceDetails
 }
 
+
 /**
  * Prepares the creation of a chain space extrinsic for later dispatch to the blockchain.
  * @param chainSpace - The ChainSpace object containing necessary information for creating the ChainSpace on the blockchain.
@@ -216,6 +219,7 @@ export async function prepareCreateSpaceExtrinsic(
     );
   }
 }
+
 
 /**
  * Dispatches a ChainSpace creation transaction to the CORD blockchain.
@@ -274,6 +278,7 @@ export async function dispatchToChain(
   }
 }
 
+
 /**
  * Prepares the creation of a sub-space extrinsic for later dispatch to the blockchain.
  * @param chainSpace - The ChainSpace object containing necessary information for creating the ChainSpace on the blockchain.
@@ -299,6 +304,7 @@ export async function prepareCreateSubSpaceExtrinsic(
     )
   }
 }
+
 
 /**
  * Dispatches a Sub-ChainSpace creation transaction to the CORD blockchain.
@@ -402,6 +408,7 @@ export async function sudoApproveChainSpace(
   }
 }
 
+
 /**
  * Generates a unique URI for an authorization within a ChainSpace.
  *
@@ -460,8 +467,9 @@ export async function getUriForAuthorization(
   return authorizationUri
 }
 
+
 /**
- * Dispatches a delegate authorization request to the CORD blockchain.
+ * Prepares a delegate authorization request to the CORD blockchain, creating a extrinsic for later dispatch.
  *
  * @remarks
  * This function handles the submission of delegate authorization requests to the CORD blockchain. It manages
@@ -478,12 +486,12 @@ export async function getUriForAuthorization(
  *
  * @internal
  */
-function dispatchDelegateAuthorizationTx(
+export async function prepareDelegateAuthorizationExtrinsic(
   permission: PermissionType,
   spaceId: string,
   delegateAddress: string,
   authId: string
-) {
+):Promise<SubmittableExtrinsic> {
   const api = ConfigService.get('api')
 
   switch (permission) {
@@ -499,6 +507,7 @@ function dispatchDelegateAuthorizationTx(
       )
   }
 }
+
 
 /**
  * Dispatches a delegate authorization transaction to the CORD blockchain.
@@ -546,7 +555,7 @@ export async function dispatchDelegateAuthorization(
     const spaceId = uriToIdentifier(request.uri)
     const delegatorAuthId = uriToIdentifier(authorizationUri)
 
-    const extrinsic = dispatchDelegateAuthorizationTx(
+    const extrinsic = await prepareDelegateAuthorizationExtrinsic(
       request.permission,
       spaceId,
       request.delegateAddress,
@@ -562,6 +571,7 @@ export async function dispatchDelegateAuthorization(
     )
   }
 }
+
 
 /**
  * Decodes the details of a space from its blockchain-encoded representation.
@@ -598,6 +608,7 @@ function decodeSpaceDetailsfromChain(
 
   return decodedDetails
 }
+
 
 /**
  * Fetches space details from the blockchain based on a given space URI.
@@ -655,6 +666,7 @@ export async function fetchFromChain(
   }
 }
 
+
 /**
  * Decodes a numeric permission bitset from the blockchain into a `PermissionType`.
  *
@@ -701,6 +713,7 @@ function authorizationPermissionsFromChain(
   return permissions
 }
 
+
 /**
  * Decodes the details of a space authorization from its blockchain representation.
  *
@@ -738,6 +751,7 @@ function decodeAuthorizationDetailsfromChain(
   }
   return decodedDetails
 }
+
 
 /**
  * Fetches authorization details from the CORD chain based on a given authorization ID.
@@ -798,6 +812,7 @@ export async function fetchAuthorizationFromChain(
     )
   }
 }
+
 
 /**
  * Prepares an update transaction capacity extrinsic for later dispatch to the blockchain.

--- a/packages/chain-space/src/ChainSpace.ts
+++ b/packages/chain-space/src/ChainSpace.ts
@@ -91,6 +91,7 @@ export async function buildFromProperties(
   }
 }
 
+
 /**
  * Authorizes a delegate within a ChainSpace, allowing them to perform actions on behalf of the creator.
  *

--- a/packages/schema/src/Schema.chain.ts
+++ b/packages/schema/src/Schema.chain.ts
@@ -27,6 +27,7 @@ import type {
   Option,
   CordKeyringPair,
   SchemaUri,
+  SubmittableExtrinsic,
 } from '@cord.network/types'
 
 import type { PalletSchemaSchemaEntry } from '@cord.network/augment-api'
@@ -54,7 +55,6 @@ import {
     encodeCborSchema,
     verifyDataStructure
 } from './Schema.js'
-
 
 /**
  * Checks if a given schema is stored on the blockchain.
@@ -197,6 +197,39 @@ export function getUriForSchema(
 
 
 /**
+ * Prepares a blockchain transaction to store a schema on-chain.
+ *
+ * This function creates an extrinsic for the blockchain transaction to store a schema.
+ * It encodes the schema using CBOR serialization and creates an extrinsic for the blockchain
+ * transaction to store the schema. The extrinsic is prepared for submission to the blockchain.
+ *
+ * ### Parameters:
+ * @param schema - The schema object to be stored on-chain. It should conform to the `ISchema` interface
+ *                 used in the Cord network.
+ *
+ * ### Returns:
+ * @returns A promise that resolves to a `SubmittableExtrinsic` object representing the blockchain transaction
+ *          to store the schema. The extrinsic is ready for signing and submission to the blockchain.
+ *
+ * ### Example Usage:
+ * ```typescript
+ * const schema = { title: 'Example Schema', properties: { id: { type: 'string' } } };
+ * const extrinsic = await prepareCreateExtrinsic(schema);
+ * ```
+ */
+export async function prepareCreateExtrinsic(
+  schema: ISchema,
+): Promise<SubmittableExtrinsic> {
+
+  const api = ConfigService.get('api')
+  const encodedSchema = encodeCborSchema(schema);
+  const extrinsic = api.tx.schema.create(encodedSchema);
+
+  return extrinsic
+}
+
+
+/**
  * Dispatches a schema to the blockchain for storage, ensuring its uniqueness, immutability,
  * and verifiability. This function encodes the schema, creates a blockchain transaction,
  * and submits it using the author's account for signing and submission.
@@ -245,15 +278,12 @@ export async function dispatchToChain(
   authorAccount: CordKeyringPair,
 ): Promise<SchemaId> {
   try {
-    const api = ConfigService.get('api')
-
     const exists = await isSchemaStored(schema)
     if (exists) {
       return schema.$id
     }
 
-    const encodedSchema = encodeCborSchema(schema);
-    const extrinsic = api.tx.schema.create(encodedSchema);
+    const extrinsic = await prepareCreateExtrinsic(schema);
 
     await Chain.signAndSubmitTx(extrinsic, authorAccount)
 
@@ -284,7 +314,7 @@ export async function dispatchToChain(
  *
  * @internal
  */
-function schemaInputFromChain(
+export function schemaInputFromChain(
   input: Bytes,
   schemaUri: ISchema['$id']
 ): ISchema {
@@ -330,7 +360,7 @@ function schemaInputFromChain(
  *
  * @internal
  */
-function fromChain(
+export function fromChain(
   encodedEntry: Option<PalletSchemaSchemaEntry>,
   schemaUri: ISchema['$id']
 ): ISchemaAccountsDetails | null {

--- a/packages/statement/src/Statement.chain.ts
+++ b/packages/statement/src/Statement.chain.ts
@@ -108,6 +108,7 @@ export async function isStatementStored(
   return !encoded.isNone
 }
 
+
 /**
  * Generates a unique URI for a statement based on its digest, space URI, and creator URI.
  *
@@ -158,6 +159,7 @@ export function getUriForStatement(
 
   return statementUri
 }
+
 
 /**
  * This function dispatches a statement entry to a blockchain after preparing the extrinsic
@@ -221,6 +223,7 @@ export async function dispatchRegisterToChain(
   }
 }
 
+
 /**
  * This function prepares and returns a SubmittableExtrinsic for registering a statement on
  * the blockchain.
@@ -279,6 +282,49 @@ export async function prepareExtrinsicToRegister(
   }
 }
 
+
+/**
+ * This function prepares and returns a SubmittableExtrinsic for updating a statement on the
+ * blockchain. 
+ * @param {IStatementEntry} stmtEntry - The `stmtEntry` parameter is an object of type
+ * `IStatementEntry`, which contains information about a statement entry.
+ *
+ * @param {AuthorizationUri} authorizationUri - The `authorizationUri` parameter in the
+ * `prepareExtrinsicToUpdate` function is a URI that represents the authorization needed for the
+ * statement entry. It is used to identify and retrieve the authorization details required for
+ * updating the statement on the chain.
+ *
+ * @returns A `SubmittableExtrinsic` is being returned from the `prepareExtrinsicToUpdate` function.
+ */
+export async function prepareExtrinsicToUpdate(
+  stmtEntry: IStatementEntry,
+  authorizationUri: AuthorizationUri,
+): Promise<SubmittableExtrinsic> { 
+    const api = ConfigService.get('api')
+    const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
+
+    /* NOTE:
+     * Check for existence of the statement with new digest before creating,
+     * to avoid sending avoidable transactions to the chain.
+     * Responsiblity lies on the application for above check.
+     * Example:
+     * const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri)
+     *  if (exists) {
+     *   return stmtEntry.elementUri
+     *  }
+     */
+
+    const stmtIdDigest = uriToStatementIdAndDigest(stmtEntry.elementUri)
+    const extrinsic = api.tx.statement.update(
+      stmtIdDigest.identifier,
+      stmtEntry.digest,
+      authorizationId
+    )
+
+    return extrinsic
+};
+
+
 /**
  * Dispatches a statement update transaction to the CORD blockchain.
  *
@@ -325,20 +371,15 @@ export async function dispatchUpdateToChain(
   authorizationUri: AuthorizationUri,
 ): Promise<StatementUri> {
   try {
-    const api = ConfigService.get('api')
-    const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
     const exists = await isStatementStored(stmtEntry.digest, stmtEntry.spaceUri)
-
     if (exists) {
       return stmtEntry.elementUri
     }
 
-    const stmtIdDigest = uriToStatementIdAndDigest(stmtEntry.elementUri)
-    const extrinsic = api.tx.statement.update(
-      stmtIdDigest.identifier,
-      stmtEntry.digest,
-      authorizationId
+    const extrinsic = await prepareExtrinsicToUpdate(
+      stmtEntry,
+      authorizationUri,
     )
 
     await Chain.signAndSubmitTx(extrinsic, authorAccount)
@@ -350,6 +391,7 @@ export async function dispatchUpdateToChain(
     )
   }
 }
+
 
 /**
  * This function dispatches a revocation transaction to a blockchain network after preparing
@@ -393,6 +435,7 @@ export async function dispatchRevokeToChain(
     )
   }
 }
+
 
 /**
  * Dispatches a statement revocation transaction to the CORD blockchain.
@@ -447,6 +490,36 @@ export async function prepareExtrinsicToRevoke(
   }
 }
 
+
+/**
+ * This function prepares and returns a SubmittableExtrinsic for restoring a statement on the
+ * blockchain.
+ * @param {StatementUri} statementUri - The `statementUri` parameter in the `prepareExtrinsicToRestore`
+ * function is a URI that represents the statement that you want to restore on the chain.
+ *
+ * @param {AuthorizationUri} authorizationUri - The `authorizationUri` parameter in the
+ * `prepareExtrinsicToRestore` function is a URI that represents the authorization needed for the
+ * statement entry. It is used to identify and retrieve the authorization details required for
+ * restoring the statement on the chain.
+ *
+ * @returns A `SubmittableExtrinsic` is being returned from the `prepareExtrinsicToRestore` function.
+ */
+export async function prepareExtrinsicToRestore(
+  statementUri: StatementUri,
+  authorizationUri: AuthorizationUri,
+): Promise<SubmittableExtrinsic> {
+  const api = ConfigService.get('api')
+  const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
+
+  const stmtIdDigest = uriToStatementIdAndDigest(statementUri)
+  const stmtId = stmtIdDigest.identifier
+
+  const extrinsic = api.tx.statement.restore(stmtId, authorizationId)
+
+  return extrinsic;
+}
+
+
 /**
  * Dispatches a statement restoration transaction to the CORD blockchain.
  *
@@ -486,13 +559,10 @@ export async function dispatchRestoreToChain(
   authorizationUri: AuthorizationUri,
 ): Promise<void> {
   try {
-    const api = ConfigService.get('api')
-    const authorizationId: AuthorizationId = uriToIdentifier(authorizationUri)
 
-    const stmtIdDigest = uriToStatementIdAndDigest(statementUri)
-    const stmtId = stmtIdDigest.identifier
-
-    const extrinsic = api.tx.statement.restore(stmtId, authorizationId)
+    const extrinsic = await prepareExtrinsicToRestore(
+      statementUri, authorizationUri
+    )
 
     await Chain.signAndSubmitTx(extrinsic, authorAccount)
   } catch (error) {
@@ -501,6 +571,7 @@ export async function dispatchRestoreToChain(
     )
   }
 }
+
 
 /**
  * Decodes statement details from their blockchain-encoded format.
@@ -546,6 +617,7 @@ export function decodeStatementDetailsfromChain(
   }
   return statement
 }
+
 
 /**
  * Retrieves detailed state information of a statement from the CORD blockchain.
@@ -593,6 +665,7 @@ export async function getDetailsfromChain(
 
   return decodedDetails
 }
+
 
 /**
  * Fetches the state of a statement element from the CORD blockchain.

--- a/packages/statement/src/Statement.ts
+++ b/packages/statement/src/Statement.ts
@@ -90,6 +90,7 @@ export function verifyDataStructure(input: IStatementEntryAccountType): void {
   DataUtils.verifyIsHex(input.digest, 256)
 }
 
+
 /**
  * Constructs a `IStatementEntry` object from given properties.
  *
@@ -142,6 +143,7 @@ export function buildFromProperties(
   return statement
 }
 
+
 /**
  * Constructs an updated `IStatementEntry` object using the provided properties.
  *
@@ -192,6 +194,7 @@ export function buildFromUpdateProperties(
   return statement
 }
 
+
 /**
  * Custom Type Guard to determine input being of type IStatement using the StatementUtils errorCheck.
  *
@@ -206,6 +209,7 @@ export function isIStatement(input: unknown): input is IStatementEntryAccountTyp
   }
   return true
 }
+
 
 /**
  * Verifies a statement's properties against provided parameters.


### PR DESCRIPTION
- Extension ops requires some more methods to have the split of `preparing` and `submitting` of SDK methods.

Example usage:
Extension provides us a signer for a given chain address. This does not expose the private keys, so our current methods will not be usable from extension (polkadot.js). 

Splitting creation and submission of extrinsics allows to achieve sending transactions from extension, as extension does not have a `KeyRingPair` but only a `Signer`.


_Before(For Scripting UseCase)_
```
  // authorIdentity is a KeyRingPair with encoded private keys.
  const space = await Cord.ChainSpace.dispatchToChain(
    spaceProperties,
    authorIdentity,
  )
 ```

_For extension, example of creating a chain-space:_
```
// chainSpace object is a builder obtained from `buildFromProperties`
// Observe below operation does not require any keys.
const extrinsic = await Cord.ChainSpace.prepareCreateSpaceExtrinsic(chainSpace); 

// Sign the prepared extrinsic and dispatch from extension using `Signer`, not the `KeyRingPair`
extrinsic.signAndSend(account.address, { signer: injector.signer }, ({ status }) => {
    if (status.isInBlock) {
        console.log(`Completed at block hash #${status.asInBlock.toString()}`);
    } else {
        console.log(`Current status: ${status.type}`);
    }
}).catch((error: any) => {
    console.log(':( transaction failed', error);
});
```

For more information: 
https://polkadot.js.org/docs/extension/cookbook/


@prashant4dev  @RCCodeBase 
